### PR TITLE
feat: add WP-CLI console

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -34,6 +34,58 @@ test('should correctly load /wp-admin without the trailing slash', async ({
 	);
 });
 
+test('should open, resize, and close the WP-CLI console', async ({
+	website,
+}) => {
+	await website.goto('./');
+	await website.ensureSiteManagerIsClosed();
+
+	await website.page.getByLabel('Open WP-CLI console').click();
+
+	const consolePanel = website.page.getByLabel('WP-CLI console', {
+		exact: true,
+	});
+	await expect(consolePanel).toBeVisible();
+	await expect(
+		consolePanel.getByRole('heading', { name: 'WP-CLI' })
+	).toBeVisible();
+	await expect(
+		consolePanel.getByText(
+			'Run commands against the active Playground site.'
+		)
+	).toBeVisible();
+	await expect(
+		consolePanel.getByText(
+			'Try `wp help`, `wp plugin list`, or `wp option get home`.'
+		)
+	).toBeVisible();
+
+	const initialBox = await consolePanel.boundingBox();
+	expect(initialBox).not.toBeNull();
+
+	const resizeHandle = consolePanel.getByLabel('Resize WP-CLI console');
+	const handleBox = await resizeHandle.boundingBox();
+	expect(handleBox).not.toBeNull();
+
+	await website.page.mouse.move(
+		handleBox!.x + handleBox!.width / 2,
+		handleBox!.y + handleBox!.height / 2
+	);
+	await website.page.mouse.down();
+	await website.page.mouse.move(
+		handleBox!.x + handleBox!.width / 2,
+		handleBox!.y + 120
+	);
+	await website.page.mouse.up();
+
+	const resizedBox = await consolePanel.boundingBox();
+	expect(resizedBox).not.toBeNull();
+	expect(resizedBox!.height).toBeGreaterThan(initialBox!.height + 80);
+
+	await consolePanel.getByLabel('Close WP-CLI console').click();
+	await expect(consolePanel).not.toBeVisible();
+});
+
 SupportedPHPVersions.forEach(async (version) => {
 	test(`should switch PHP version to ${version}`, async ({ website }) => {
 		await website.goto(`./`);

--- a/packages/playground/website/src/components/browser-chrome/index.tsx
+++ b/packages/playground/website/src/components/browser-chrome/index.tsx
@@ -12,10 +12,13 @@ import {
 import { SyncLocalFilesButton } from '../sync-local-files-button';
 import { Dropdown, Icon } from '@wordpress/components';
 import { Modal } from '../../components/modal';
-import { cog, category } from '@wordpress/icons';
+import { cog, category, code } from '@wordpress/icons';
 import Button from '../button';
 import { ActiveSiteSettingsForm } from '../site-manager/site-settings-form';
-import { setSiteManagerOpen } from '../../lib/state/redux/slice-ui';
+import {
+	setSiteManagerOpen,
+	setWpCliConsoleOpen,
+} from '../../lib/state/redux/slice-ui';
 import { SiteManagerIcon } from '@wp-playground/components';
 import {
 	SavedPlaygroundsOverlay,
@@ -44,6 +47,9 @@ export default function BrowserChrome({
 	const dispatch = useAppDispatch();
 	const siteManagerIsOpen = useAppSelector(
 		(state) => state.ui.siteManagerIsOpen
+	);
+	const wpCliConsoleIsOpen = useAppSelector(
+		(state) => state.ui.wpCliConsoleIsOpen
 	);
 	const addressBarClass = classNames(css.addressBarSlot, {
 		[css.isHidden]: !showAddressBar,
@@ -105,6 +111,30 @@ export default function BrowserChrome({
 						>
 							<Icon icon={category} size={20} />
 						</Button>
+
+						{clientInfo && (
+							<Button
+								variant="browser-chrome"
+								aria-label={
+									wpCliConsoleIsOpen
+										? 'Close WP-CLI console'
+										: 'Open WP-CLI console'
+								}
+								aria-pressed={wpCliConsoleIsOpen}
+								onClick={() => {
+									dispatch(
+										setWpCliConsoleOpen(!wpCliConsoleIsOpen)
+									);
+								}}
+								style={{
+									fill: '#FFF',
+									alignItems: 'center',
+									display: 'flex',
+								}}
+							>
+								<Icon icon={code} size={28} />
+							</Button>
+						)}
 
 						<Button
 							variant="browser-chrome"

--- a/packages/playground/website/src/components/layout/index.tsx
+++ b/packages/playground/website/src/components/layout/index.tsx
@@ -3,8 +3,8 @@ import css from './style.module.css';
 import { SiteManager } from '../site-manager';
 import { CSSTransition } from 'react-transition-group';
 import type { PlaygroundReduxState } from '../../lib/state/redux/store';
-import { useAppSelector } from '../../lib/state/redux/store';
-import { useState, useRef, lazy, Suspense } from 'react';
+import { useAppDispatch, useAppSelector } from '../../lib/state/redux/store';
+import { useState, useEffect, useRef, lazy, Suspense } from 'react';
 import type { ExportFormValues } from '../../github/github-export-form/form';
 import { asPullRequestAction } from '../../github/github-export-form/form';
 import { GitHubOAuthGuardModal } from '../../github/github-oauth-guard';
@@ -20,10 +20,14 @@ import { MissingSiteModal } from '../missing-site-modal';
 import { RenameSiteModal } from '../rename-site-modal';
 import { DeleteSiteModal } from '../delete-site-modal';
 import { SaveSiteModal } from '../save-site-modal';
-import { modalSlugs } from '../../lib/state/redux/slice-ui';
+import {
+	modalSlugs,
+	setWpCliConsoleOpen,
+} from '../../lib/state/redux/slice-ui';
 import { GitHubPrivateRepoAuthModal } from '../github-private-repo-auth-modal';
 import { BlueprintUrlModal } from '../blueprint-url-modal';
 import { ModalLoadingFallback } from '../modal-loading-fallback';
+import WpCliConsole from '../wp-cli-console';
 
 /**
  * Lazy modal wrapper component to reduce Suspense repetition
@@ -60,14 +64,44 @@ function getDisplayModeFromQuery(): DisplayMode {
 }
 
 export function Layout() {
+	const dispatch = useAppDispatch();
 	const siteManagerIsOpen = useAppSelector(
 		(state) => state.ui.siteManagerIsOpen
 	);
+	const wpCliConsoleIsOpen = useAppSelector(
+		(state) => state.ui.wpCliConsoleIsOpen
+	);
 	const siteManagerWrapperRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (
+				event.key !== '`' ||
+				event.altKey ||
+				event.ctrlKey ||
+				event.metaKey
+			) {
+				return;
+			}
+			const target = event.target as HTMLElement | null;
+			if (
+				target?.closest(
+					'input, textarea, select, [contenteditable="true"], .xterm'
+				)
+			) {
+				return;
+			}
+			event.preventDefault();
+			dispatch(setWpCliConsoleOpen(!wpCliConsoleIsOpen));
+		};
+		window.addEventListener('keydown', onKeyDown);
+		return () => window.removeEventListener('keydown', onKeyDown);
+	}, [dispatch, wpCliConsoleIsOpen]);
 
 	return (
 		<div className={`${css.layout}`}>
 			<Modals />
+			<WpCliConsole />
 			<CSSTransition
 				nodeRef={siteManagerWrapperRef}
 				in={siteManagerIsOpen}

--- a/packages/playground/website/src/components/wp-cli-console/index.tsx
+++ b/packages/playground/website/src/components/wp-cli-console/index.tsx
@@ -1,0 +1,410 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import css from './style.module.css';
+import 'xterm/css/xterm.css';
+import { Terminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
+import { splitShellCommand } from '@php-wasm/util';
+import type { StreamedPHPResponse } from '@php-wasm/universal';
+import {
+	getActiveClientInfo,
+	useAppDispatch,
+	useAppSelector,
+} from '../../lib/state/redux/store';
+import { setWpCliConsoleOpen } from '../../lib/state/redux/slice-ui';
+
+const WP_CLI_PATH = '/tmp/wp-cli.phar';
+const WP_CLI_URL = 'https://playground.wordpress.net/wp-cli.phar';
+
+function writeTerminalText(term: Terminal, text: string) {
+	term.write(text.replace(/\r?\n/g, '\r\n'));
+}
+
+async function writeStreamToTerminal(
+	term: Terminal,
+	reader: ReadableStreamDefaultReader<Uint8Array>,
+	isAborted = () => false
+) {
+	const decoder = new TextDecoder();
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) {
+				break;
+			}
+			writeTerminalText(term, decoder.decode(value, { stream: true }));
+		}
+		const tail = decoder.decode();
+		if (tail) {
+			writeTerminalText(term, tail);
+		}
+	} catch (error) {
+		if (!isAborted()) {
+			throw error;
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+export function WpCliConsole() {
+	const isOpen = useAppSelector((state) => state.ui.wpCliConsoleIsOpen);
+	const clientInfo = useAppSelector(getActiveClientInfo);
+	const playground = clientInfo?.client;
+	const dispatch = useAppDispatch();
+
+	const terminalContainer = useRef<HTMLDivElement>(null);
+	const terminalRef = useRef<Terminal>();
+	const fitAddonRef = useRef<FitAddon>();
+	const isRunningCommand = useRef(false);
+	const currentProcess = useRef<{ terminate: () => Promise<void> } | null>(
+		null
+	);
+	const history = useRef<string[]>([]);
+	const currentHistoryEntry = useRef(-1);
+	const [downloading, setDownloading] = useState(false);
+	const [downloadProgress, setDownloadProgress] = useState<number>();
+
+	const ensureWpCli = useCallback(async () => {
+		if (!playground) {
+			return;
+		}
+		await playground.isReady();
+		if (await playground.fileExists(WP_CLI_PATH)) {
+			return;
+		}
+		setDownloading(true);
+		setDownloadProgress(undefined);
+		try {
+			const response = await fetch(WP_CLI_URL);
+			if (!response.ok) {
+				throw new Error(
+					`Failed to download WP-CLI: ${response.status} ${response.statusText}`
+				);
+			}
+			const total = Number(response.headers.get('content-length')) || 0;
+			const reader = response.body?.getReader();
+			if (!reader) {
+				throw new Error('Failed to read WP-CLI download stream.');
+			}
+			const chunks: Uint8Array[] = [];
+			let received = 0;
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) {
+					break;
+				}
+				chunks.push(value);
+				received += value.length;
+				if (total) {
+					setDownloadProgress(received / total);
+				}
+			}
+			const wpCli = new Uint8Array(received);
+			let offset = 0;
+			for (const chunk of chunks) {
+				wpCli.set(chunk, offset);
+				offset += chunk.length;
+			}
+			await playground.writeFile(WP_CLI_PATH, wpCli);
+		} finally {
+			setDownloading(false);
+			setDownloadProgress(undefined);
+		}
+	}, [playground]);
+
+	const runWpCli = useCallback(
+		async (args: string[]) => {
+			if (!playground || !terminalRef.current) {
+				return;
+			}
+			const term = terminalRef.current;
+			await ensureWpCli();
+			await playground.isReady();
+			const documentRoot = await playground.documentRoot;
+			const response = (await playground.cli([
+				'php',
+				WP_CLI_PATH,
+				`--path=${documentRoot}`,
+				...args,
+			])) as StreamedPHPResponse & {
+				terminate?: () => Promise<void> | void;
+			};
+
+			let aborted = false;
+			const stdoutReader = response.stdout.getReader();
+			const stderrReader = response.stderr.getReader();
+			const activeProcess = {
+				async terminate() {
+					if (aborted) {
+						return;
+					}
+					aborted = true;
+					try {
+						await stdoutReader.cancel();
+					} catch {
+						/* ignore termination errors */
+					}
+					try {
+						await stderrReader.cancel();
+					} catch {
+						/* ignore termination errors */
+					}
+					if (typeof response.terminate === 'function') {
+						try {
+							await response.terminate();
+						} catch {
+							/* ignore termination errors */
+						}
+					}
+				},
+			};
+			currentProcess.current = activeProcess;
+
+			let exitCode = 0;
+			try {
+				const stdout = writeStreamToTerminal(
+					term,
+					stdoutReader,
+					() => aborted
+				);
+				const stderr = writeStreamToTerminal(
+					term,
+					stderrReader,
+					() => aborted
+				);
+				exitCode = await response.exitCode.catch((error) => {
+					if (!aborted) {
+						throw error;
+					}
+					return 130;
+				});
+				await Promise.all([stdout, stderr]);
+			} finally {
+				if (currentProcess.current === activeProcess) {
+					currentProcess.current = null;
+				}
+			}
+			if (!aborted && exitCode !== 0) {
+				writeTerminalText(
+					term,
+					`\r\nProcess exited with code ${exitCode}`
+				);
+			}
+		},
+		[ensureWpCli, playground]
+	);
+
+	const abortActiveProcess = useCallback(async () => {
+		const process = currentProcess.current;
+		if (!process) {
+			return;
+		}
+		try {
+			await process.terminate();
+		} finally {
+			if (currentProcess.current === process) {
+				currentProcess.current = null;
+			}
+		}
+	}, []);
+
+	const runCommand = useCallback(
+		async (rawCommand: string) => {
+			const term = terminalRef.current;
+			if (!term) {
+				return;
+			}
+			const trimmedCommand = rawCommand.trim();
+			if (trimmedCommand) {
+				history.current.unshift(trimmedCommand);
+			}
+			currentHistoryEntry.current = -1;
+			isRunningCommand.current = true;
+			try {
+				const args = splitShellCommand(trimmedCommand);
+				const command = args.shift();
+				switch (command) {
+					case undefined:
+						break;
+					case '':
+						break;
+					case 'clear':
+						term.clear();
+						break;
+					case 'exit':
+					case 'quit':
+						dispatch(setWpCliConsoleOpen(false));
+						break;
+					case 'wp':
+						await runWpCli(args);
+						break;
+					default:
+						writeTerminalText(
+							term,
+							`${command}: command not found`
+						);
+				}
+			} catch (error) {
+				const message =
+					error instanceof Error ? error.message : String(error);
+				writeTerminalText(term, `Error: ${message}`);
+			} finally {
+				writeTerminalText(term, '\r\n$ ');
+				isRunningCommand.current = false;
+			}
+		},
+		[dispatch, runWpCli]
+	);
+
+	useEffect(() => {
+		if (!terminalContainer.current || !playground) {
+			return;
+		}
+
+		const term = new Terminal({
+			cursorBlink: true,
+			fontFamily:
+				'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+			fontSize: 13,
+			theme: {
+				background: '#0b0f14',
+				foreground: '#eef2f8',
+			},
+		});
+		const fitAddon = new FitAddon();
+		term.loadAddon(fitAddon);
+		term.open(terminalContainer.current);
+		fitAddon.fit();
+
+		terminalRef.current = term;
+		fitAddonRef.current = fitAddon;
+		writeTerminalText(
+			term,
+			'WP-CLI console. Type `wp help` to get started.\r\n$ '
+		);
+
+		let command = '';
+		const clearPromptLine = () => {
+			term.write('\x1b[2K\r$ ');
+		};
+		let lastInputChar = '';
+		const disposable = term.onData((input) => {
+			for (const char of input) {
+				if (char === '\u0003') {
+					term.write('^C');
+					command = '';
+					if (isRunningCommand.current) {
+						void abortActiveProcess();
+					} else {
+						writeTerminalText(term, '\r\n$ ');
+					}
+					lastInputChar = char;
+					continue;
+				}
+				if (isRunningCommand.current) {
+					lastInputChar = char;
+					continue;
+				}
+				switch (char) {
+					case '\r':
+					case '\n':
+						if (char === '\n' && lastInputChar === '\r') {
+							break;
+						}
+						writeTerminalText(term, '\r\n');
+						void runCommand(command);
+						command = '';
+						break;
+					case '\u007F':
+						if (command.length > 0) {
+							command = command.slice(0, -1);
+							term.write('\b \b');
+						}
+						break;
+					default:
+						if (char >= ' ' || char >= '\u00a0') {
+							command += char;
+							term.write(char);
+						}
+				}
+				lastInputChar = char;
+			}
+		});
+
+		term.attachCustomKeyEventHandler((event) => {
+			if (event.type !== 'keydown' || event.metaKey || event.ctrlKey) {
+				return true;
+			}
+			if (event.code === 'ArrowUp') {
+				if (currentHistoryEntry.current < history.current.length - 1) {
+					currentHistoryEntry.current += 1;
+					command =
+						history.current[currentHistoryEntry.current] || '';
+					clearPromptLine();
+					term.write(command);
+				}
+				return false;
+			}
+			if (event.code === 'ArrowDown') {
+				if (currentHistoryEntry.current > 0) {
+					currentHistoryEntry.current -= 1;
+					command =
+						history.current[currentHistoryEntry.current] || '';
+				} else {
+					currentHistoryEntry.current = -1;
+					command = '';
+				}
+				clearPromptLine();
+				term.write(command);
+				return false;
+			}
+			return true;
+		});
+
+		return () => {
+			void currentProcess.current?.terminate();
+			disposable.dispose();
+			term.dispose();
+			terminalRef.current = undefined;
+			fitAddonRef.current = undefined;
+		};
+	}, [playground, runCommand]);
+
+	useEffect(() => {
+		if (isOpen) {
+			window.setTimeout(() => {
+				fitAddonRef.current?.fit();
+				terminalRef.current?.focus();
+			}, 0);
+		}
+	}, [isOpen]);
+
+	useEffect(() => {
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key === 'Escape' && isOpen) {
+				dispatch(setWpCliConsoleOpen(false));
+			}
+		};
+		window.addEventListener('keydown', onKeyDown);
+		return () => window.removeEventListener('keydown', onKeyDown);
+	}, [dispatch, isOpen]);
+
+	if (!playground) {
+		return null;
+	}
+
+	return (
+		<div className={`${css.wrapper} ${isOpen ? css.open : ''}`}>
+			{downloading && (
+				<progress
+					className={css.progress}
+					value={downloadProgress}
+					max={1}
+				/>
+			)}
+			<div className={css.terminal} ref={terminalContainer} />
+		</div>
+	);
+}
+
+export default WpCliConsole;

--- a/packages/playground/website/src/components/wp-cli-console/index.tsx
+++ b/packages/playground/website/src/components/wp-cli-console/index.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties, PointerEvent as ReactPointerEvent } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import css from './style.module.css';
 import 'xterm/css/xterm.css';
@@ -5,6 +6,8 @@ import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import { splitShellCommand } from '@php-wasm/util';
 import type { StreamedPHPResponse } from '@php-wasm/universal';
+import { Icon } from '@wordpress/components';
+import { close } from '@wordpress/icons';
 import {
 	getActiveClientInfo,
 	useAppDispatch,
@@ -14,6 +17,9 @@ import { setWpCliConsoleOpen } from '../../lib/state/redux/slice-ui';
 
 const WP_CLI_PATH = '/tmp/wp-cli.phar';
 const WP_CLI_URL = 'https://playground.wordpress.net/wp-cli.phar';
+const DEFAULT_PANEL_HEIGHT = 360;
+const MIN_PANEL_HEIGHT = 220;
+const PANEL_MARGIN = 72;
 
 function writeTerminalText(term: Terminal, text: string) {
 	term.write(text.replace(/\r?\n/g, '\r\n'));
@@ -52,6 +58,7 @@ export function WpCliConsole() {
 	const playground = clientInfo?.client;
 	const dispatch = useAppDispatch();
 
+	const wrapperRef = useRef<HTMLDivElement>(null);
 	const terminalContainer = useRef<HTMLDivElement>(null);
 	const terminalRef = useRef<Terminal>();
 	const fitAddonRef = useRef<FitAddon>();
@@ -63,6 +70,17 @@ export function WpCliConsole() {
 	const currentHistoryEntry = useRef(-1);
 	const [downloading, setDownloading] = useState(false);
 	const [downloadProgress, setDownloadProgress] = useState<number>();
+	const [panelHeight, setPanelHeight] = useState(DEFAULT_PANEL_HEIGHT);
+
+	const closeConsole = useCallback(() => {
+		dispatch(setWpCliConsoleOpen(false));
+	}, [dispatch]);
+
+	const fitTerminal = useCallback(() => {
+		requestAnimationFrame(() => {
+			fitAddonRef.current?.fit();
+		});
+	}, []);
 
 	const ensureWpCli = useCallback(async () => {
 		if (!playground) {
@@ -233,7 +251,7 @@ export function WpCliConsole() {
 						break;
 					case 'exit':
 					case 'quit':
-						dispatch(setWpCliConsoleOpen(false));
+						closeConsole();
 						break;
 					case 'wp':
 						await runWpCli(args);
@@ -253,7 +271,7 @@ export function WpCliConsole() {
 				isRunningCommand.current = false;
 			}
 		},
-		[dispatch, runWpCli]
+		[closeConsole, runWpCli]
 	);
 
 	useEffect(() => {
@@ -373,11 +391,15 @@ export function WpCliConsole() {
 	useEffect(() => {
 		if (isOpen) {
 			window.setTimeout(() => {
-				fitAddonRef.current?.fit();
+				fitTerminal();
 				terminalRef.current?.focus();
 			}, 0);
 		}
-	}, [isOpen]);
+	}, [fitTerminal, isOpen]);
+
+	useEffect(() => {
+		fitTerminal();
+	}, [fitTerminal, panelHeight]);
 
 	useEffect(() => {
 		const onKeyDown = (event: KeyboardEvent) => {
@@ -389,12 +411,85 @@ export function WpCliConsole() {
 		return () => window.removeEventListener('keydown', onKeyDown);
 	}, [dispatch, isOpen]);
 
+	const startResize = (event: ReactPointerEvent<HTMLButtonElement>) => {
+		event.preventDefault();
+		const panel = wrapperRef.current;
+		if (!panel) {
+			return;
+		}
+
+		const pointerId = event.pointerId;
+		const startY = event.clientY;
+		const startHeight = panel.getBoundingClientRect().height;
+		const maxHeight = Math.max(
+			MIN_PANEL_HEIGHT,
+			window.innerHeight - PANEL_MARGIN
+		);
+
+		const resize = (moveEvent: PointerEvent) => {
+			if (moveEvent.pointerId !== pointerId) {
+				return;
+			}
+			setPanelHeight(
+				Math.min(
+					maxHeight,
+					Math.max(
+						MIN_PANEL_HEIGHT,
+						startHeight + moveEvent.clientY - startY
+					)
+				)
+			);
+		};
+
+		const stopResize = (upEvent: PointerEvent) => {
+			if (upEvent.pointerId !== pointerId) {
+				return;
+			}
+			window.removeEventListener('pointermove', resize);
+			window.removeEventListener('pointerup', stopResize);
+			window.removeEventListener('pointercancel', stopResize);
+			fitTerminal();
+		};
+
+		window.addEventListener('pointermove', resize);
+		window.addEventListener('pointerup', stopResize);
+		window.addEventListener('pointercancel', stopResize);
+	};
+
 	if (!playground) {
 		return null;
 	}
 
 	return (
-		<div className={`${css.wrapper} ${isOpen ? css.open : ''}`}>
+		<div
+			aria-label="WP-CLI console"
+			className={`${css.wrapper} ${isOpen ? css.open : ''}`}
+			ref={wrapperRef}
+			role="region"
+			style={
+				{ '--wp-cli-panel-height': `${panelHeight}px` } as CSSProperties
+			}
+		>
+			<header className={css.header}>
+				<div>
+					<h2 className={css.title}>WP-CLI</h2>
+					<p className={css.description}>
+						Run commands against the active Playground site.
+					</p>
+					<p className={css.hint}>
+						Try `wp help`, `wp plugin list`, or `wp option get
+						home`.
+					</p>
+				</div>
+				<button
+					aria-label="Close WP-CLI console"
+					className={css.closeButton}
+					onClick={closeConsole}
+					type="button"
+				>
+					<Icon icon={close} size={18} />
+				</button>
+			</header>
 			{downloading && (
 				<progress
 					className={css.progress}
@@ -403,6 +498,12 @@ export function WpCliConsole() {
 				/>
 			)}
 			<div className={css.terminal} ref={terminalContainer} />
+			<button
+				aria-label="Resize WP-CLI console"
+				className={css.resizeHandle}
+				onPointerDown={startResize}
+				type="button"
+			/>
 		</div>
 	);
 }

--- a/packages/playground/website/src/components/wp-cli-console/style.module.css
+++ b/packages/playground/website/src/components/wp-cli-console/style.module.css
@@ -1,0 +1,35 @@
+.wrapper {
+	position: fixed;
+	inset: 0 0 auto 0;
+	height: min(50vh, 420px);
+	z-index: 1000;
+	display: flex;
+	flex-direction: column;
+	background: #0b0f14;
+	border-bottom: 1px solid #263241;
+	box-shadow: 0 18px 32px rgb(0 0 0 / 28%);
+	transform: translateY(-100%);
+	transition: transform 160ms ease-out;
+	pointer-events: none;
+}
+
+.open {
+	transform: translateY(0);
+	pointer-events: auto;
+}
+
+.terminal {
+	flex: 1;
+	min-height: 0;
+	padding: 10px 12px 12px;
+}
+
+.terminal :global(.xterm) {
+	height: 100%;
+}
+
+.progress {
+	width: 100%;
+	height: 4px;
+	border: 0;
+}

--- a/packages/playground/website/src/components/wp-cli-console/style.module.css
+++ b/packages/playground/website/src/components/wp-cli-console/style.module.css
@@ -1,7 +1,7 @@
 .wrapper {
 	position: fixed;
 	inset: 0 0 auto 0;
-	height: min(50vh, 420px);
+	height: var(--wp-cli-panel-height, 360px);
 	z-index: 1000;
 	display: flex;
 	flex-direction: column;
@@ -18,6 +18,55 @@
 	pointer-events: auto;
 }
 
+.header {
+	display: flex;
+	flex: 0 0 auto;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+	padding: 14px 16px 10px;
+	border-bottom: 1px solid #1b2634;
+	color: #eef2f8;
+}
+
+.title {
+	margin: 0;
+	font-size: 14px;
+	font-weight: 600;
+	line-height: 1.2;
+}
+
+.description,
+.hint {
+	margin: 4px 0 0;
+	color: #aab6c5;
+	font-size: 12px;
+	line-height: 1.35;
+}
+
+.hint {
+	color: #7f8fa3;
+}
+
+.close-button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	padding: 0;
+	color: #d9e2ee;
+	background: transparent;
+	border: 1px solid #263241;
+	border-radius: 4px;
+	cursor: pointer;
+}
+
+.close-button:hover {
+	background: #16202c;
+	border-color: #3b4b5f;
+}
+
 .terminal {
 	flex: 1;
 	min-height: 0;
@@ -32,4 +81,28 @@
 	width: 100%;
 	height: 4px;
 	border: 0;
+}
+
+.resize-handle {
+	position: absolute;
+	right: 0;
+	bottom: -5px;
+	left: 0;
+	height: 10px;
+	padding: 0;
+	background: transparent;
+	border: 0;
+	cursor: ns-resize;
+}
+
+.resize-handle::before {
+	position: absolute;
+	top: 4px;
+	left: 50%;
+	width: 48px;
+	height: 2px;
+	background: #405064;
+	border-radius: 2px;
+	content: '';
+	transform: translateX(-50%);
 }

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -152,6 +152,7 @@ export interface UIState {
 	offline: boolean;
 	siteManagerIsOpen: boolean;
 	siteManagerSection: SiteManagerSection;
+	wpCliConsoleIsOpen: boolean;
 }
 
 const query = new URL(document.location.href).searchParams;
@@ -194,6 +195,7 @@ const initialState: UIState = {
 		// your entire screen – quite a confusing experience.
 		window.innerWidth >= BREAKPOINTS.tablet,
 	siteManagerSection: 'site-details',
+	wpCliConsoleIsOpen: false,
 };
 
 const uiSlice = createSlice({
@@ -264,6 +266,9 @@ const uiSlice = createSlice({
 		) => {
 			state.siteManagerSection = action.payload;
 		},
+		setWpCliConsoleOpen: (state, action: PayloadAction<boolean>) => {
+			state.wpCliConsoleIsOpen = action.payload;
+		},
 		setSiteSlugToRename: (
 			state,
 			action: PayloadAction<string | undefined>
@@ -320,6 +325,7 @@ export const {
 	setOffline,
 	setSiteManagerOpen,
 	setSiteManagerSection,
+	setWpCliConsoleOpen,
 	setSiteSlugToRename,
 	setSiteSlugToDelete,
 } = uiSlice.actions;


### PR DESCRIPTION
## Summary
- add an xterm-based WP-CLI console to the Playground website
- toggle the console from the browser toolbar or the backtick key
- auto-download `wp-cli.phar` into `/tmp/wp-cli.phar` from the Playground-hosted asset when needed
- run `wp` commands through the current Playground `client.cli()` streaming API using the active document root
- support command history, `clear`, `exit`/`quit`, Escape close, and Ctrl+C termination for streamed CLI processes

## Current status
- Reimplemented on top of current `trunk` (`dac72f5b4`) and force-pushed over the stale conflicting head (`70bf7209f`).
- Draft while the fresh GitHub Actions run settles.

## Testing
- `git diff --check`
- `npx prettier --check packages/playground/website/src/lib/state/redux/slice-ui.ts packages/playground/website/src/components/browser-chrome/index.tsx packages/playground/website/src/components/layout/index.tsx packages/playground/website/src/components/wp-cli-console/index.tsx packages/playground/website/src/components/wp-cli-console/style.module.css`
- `NX_DAEMON=false npx nx run playground-website:lint --skip-nx-cache`
- `NX_DAEMON=false npx nx run playground-website:typecheck --skip-nx-cache`
- `NX_DAEMON=false npx nx run playground-website:build:standalone:production --skip-nx-cache`
- `NX_DAEMON=false npx nx run playground-website:test --skip-nx-cache`
- Browser smoke: served the built website + remote artifacts locally, opened with headless Chromium, opened the WP-CLI console, ran `wp --info`, and observed `WP-CLI version` with no browser console errors.
