### PR TITLE
Fix proc_open less browser test

### DIFF
--- a/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
+++ b/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
@@ -47,6 +47,9 @@ export function sandboxedSpawnHandlerFactory(
 			processApi.on('stdin', (data: Uint8Array) => {
 				processApi.stdout(data);
 			});
+			await new Promise<void>((resolve) => {
+				processApi.on('stdinEnd', () => resolve());
+			});
 			processApi.exit(0);
 		} else if (binaryName === 'php') {
 			const { php, reap } = await processManager.acquirePHPInstance({

--- a/packages/php-wasm/util/src/lib/create-spawn-handler.ts
+++ b/packages/php-wasm/util/src/lib/create-spawn-handler.ts
@@ -109,6 +109,10 @@ export class ProcessApi extends EventEmitterPolyfill {
 				this.emit('stdin', data);
 			}
 		});
+		// Emit an event when stdin is finished so consumers can await it
+		childProcess.stdin.on('finish', () => {
+			this.emit('stdinEnd');
+		});
 	}
 	stdinEnd() {
 		if (!this.childProcess.stdin.ended) {


### PR DESCRIPTION
## Motivation for the change, related issues

This change addresses a failing e2e test: `proc_open "less" echoes stdin to stdout in the browser`. The issue was that the mock `less` command exited prematurely, sometimes before PHP finished writing all stdin chunks, leading to truncated output.

## Implementation details

1.  **`packages/php-wasm/util/src/lib/create-spawn-handler.ts`**: The `ProcessApi` now emits a new `stdinEnd` event when the underlying `childProcess.stdin` stream finishes.
2.  **`packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts`**: The `less` command handler was updated to `await` the `stdinEnd` event before exiting, ensuring all input is processed.

## Testing Instructions (or ideally a Blueprint)

Run the e2e test: `proc_open "less" echoes stdin to stdout in the browser`.

---
<a href="https://cursor.com/background-agent?bcId=bc-6cc9c35c-862a-4b08-b89b-b46a80ce261a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6cc9c35c-862a-4b08-b89b-b46a80ce261a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

