### PR TITLE
test: verify wp-cli help via php.wasm

### DIFF
--- a/packages/php-wasm/node/src/test/wp-cli.spec.ts
+++ b/packages/php-wasm/node/src/test/wp-cli.spec.ts
@@ -1,0 +1,36 @@
+import { PHP } from '@php-wasm/universal';
+import { RecommendedPHPVersion } from '@wp-playground/common';
+import { readFileSync } from 'node:fs';
+import { vi } from 'vitest';
+
+vi.mock('../lib/networking/with-networking', () => ({
+	withNetworking: async (args: any) => args,
+}));
+
+import { loadNodeRuntime } from '@php-wasm/node';
+
+describe('wp-cli', () => {
+	it('prints a help message when run without arguments', async () => {
+		const php = new PHP(await loadNodeRuntime(RecommendedPHPVersion));
+		php.writeFile(
+			'/wp-cli.phar',
+			readFileSync(
+				new URL(
+					'../../../../playground/blueprints/tests/fixtures/wp-cli.phar',
+					import.meta.url
+				)
+			)
+		);
+		const result = await php.cli(['php', '/wp-cli.phar'], {
+			env: {
+				WP_CLI_ALLOW_ROOT: '1',
+				PAGER: 'cat',
+			},
+		});
+		const stdout = await result.stdoutText;
+		expect(stdout).toContain('Manage WordPress through the command-line');
+		expect(stdout).toContain('SUBCOMMANDS');
+		expect(await result.exitCode).toBe(0);
+		php.exit();
+	});
+});


### PR DESCRIPTION
## Summary
- add vitest to ensure wp-cli.phar runs under php.wasm and outputs help when no args provided

## Testing
- `npx vitest run packages/php-wasm/node/src/test/wp-cli.spec.ts --config packages/php-wasm/node/vite.config.ts` *(fails: EINVAL: invalid argument, scandir '//proc/3422/net')*

------
https://chatgpt.com/codex/tasks/task_e_689a67cc2f388328a7389ae846d413e0