### PR TITLE
Force mysqlnd to use TCP for localhost in WASM builds

### DIFF
--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -353,8 +353,10 @@ RUN if [ "$WITH_MBREGEX" = "yes" ] && [ "${PHP_VERSION:0:3}" != "7.0" ]; \
 
 # Get and patch PHP
 COPY ./php/php*.patch /root/
+COPY ./php/mysqlnd-force-tcp-localhost.patch /root/
 RUN cd /root && \
 	git apply --no-index /root/php${PHP_VERSION:0:3}*.patch -v && \
+        git apply --no-index /root/mysqlnd-force-tcp-localhost.patch -v && \
 	( [[ "${PHP_VERSION:0:3}" == '8.3' ]] && \
 		git apply --no-index /root/php-chunk-alloc-zend-assert-8.3.patch -v || \
 		( [[ "${PHP_VERSION:0:3}" == '8.4' ]] && \
@@ -367,6 +369,7 @@ RUN cd /root && \
 # Install Mysql support if needed
 RUN if [ "$WITH_MYSQL" = "yes" ]; then \
 		echo -n ' --enable-mysql --enable-pdo --with-mysql=mysqlnd --with-mysqli=mysqlnd --with-pdo-mysql=mysqlnd ' >> /root/.php-configure-flags; \
+                echo -n ' -DMYSQLND_FORCE_TCP_LOCALHOST ' >> /root/.emcc-php-wasm-flags; \
 	fi
 
 # Build the patched PHP

--- a/packages/php-wasm/compile/php/mysqlnd-force-tcp-localhost.patch
+++ b/packages/php-wasm/compile/php/mysqlnd-force-tcp-localhost.patch
@@ -1,0 +1,36 @@
+diff --git a/php-src/ext/mysqlnd/mysqlnd_connection.c b/php-src/ext/mysqlnd/mysqlnd_connection.c
+--- a/php-src/ext/mysqlnd/mysqlnd_connection.c
++++ b/php-src/ext/mysqlnd/mysqlnd_connection.c
+@@
+-    MYSQLND_STRING transport;
+-    DBG_ENTER("mysqlnd_conn_data::get_scheme");
++    MYSQLND_STRING transport;
++    DBG_ENTER("mysqlnd_conn_data::get_scheme");
++
++    /* Force TCP for 'localhost' in Emscripten/Node builds.
++       Only rewrite when no unix socket/pipe was explicitly requested. */
++#ifdef MYSQLND_FORCE_TCP_LOCALHOST
++    if (hostname.s && hostname.l == sizeof("localhost") - 1
++        && !strncasecmp(hostname.s, "localhost", hostname.l)) {
++        if (!socket_or_pipe || !socket_or_pipe->s || socket_or_pipe->l == 0) {
++            hostname.s = "127.0.0.1";
++            hostname.l = sizeof("127.0.0.1") - 1;
++            if (socket_or_pipe) {
++                socket_or_pipe->s = NULL;
++                socket_or_pipe->l = 0;
++            }
++        }
++    }
++#endif
+ #ifndef PHP_WIN32
+     if (hostname.l == sizeof("localhost") - 1 && !strncasecmp(hostname.s, "localhost", hostname.l)) {
+         DBG_INF_FMT("socket=%s", socket_or_pipe->s? socket_or_pipe->s:"n/a");
+         if (!socket_or_pipe->s) {
+             socket_or_pipe->s = "/tmp/mysql.sock";
+             socket_or_pipe->l = strlen(socket_or_pipe->s);
+         }
+         transport.l = mnd_sprintf(&transport.s, 0, "unix://%s", socket_or_pipe->s);
+         *unix_socket = TRUE;
+ #else
+     if (hostname.l == sizeof(".") - 1 && hostname.s[0] == '.') {
+         /* named pipe in socket */


### PR DESCRIPTION
## Summary
- Rewrite `localhost` to `127.0.0.1` when `MYSQLND_FORCE_TCP_LOCALHOST` is defined
- Apply the mysqlnd patch and define the macro during WASM MySQL builds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689aff9e18188328a3000d15816245c3