### PR TITLE
Run blueprints inside worker boot

### DIFF
--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -26,7 +26,6 @@ export { phpVar, phpVars } from '@php-wasm/util';
 export type { PlaygroundClient, MountDescriptor };
 
 import type { Blueprint, OnStepCompleted } from '@wp-playground/blueprints';
-import { compileBlueprint, runBlueprintSteps } from '@wp-playground/blueprints';
 import { consumeAPI } from '@php-wasm/web';
 import { ProgressTracker } from '@php-wasm/progress';
 import type { MountDescriptor, PlaygroundClient } from '@wp-playground/remote';
@@ -126,12 +125,6 @@ export async function startPlaygroundWeb({
 		blueprint = {};
 	}
 
-	const compiled = await compileBlueprint(blueprint, {
-		progress: progressTracker.stage(0.5),
-		onStepCompleted: onBlueprintStepCompleted,
-		corsProxy,
-	});
-
 	await new Promise((resolve) => {
 		iframe.src = remoteUrl;
 		iframe.addEventListener('load', resolve, false);
@@ -145,39 +138,40 @@ export async function startPlaygroundWeb({
 	) as PlaygroundClient;
 	await playground.isConnected();
 	progressTracker.pipe(playground);
+
+	// Blueprint compilation progress accounts for half of the total progress.
+	const blueprintProgress = progressTracker.stage(0.5);
 	const downloadPHPandWP = progressTracker.stage();
+
 	await playground.onDownloadProgress(downloadPHPandWP.loadingListener);
+
+	onClientConnected(playground);
+
 	await playground.boot({
 		mounts,
 		sapiName,
 		scope: scope ?? Math.random().toFixed(16),
 		shouldInstallWordPress,
-		phpVersion: compiled.versions.php,
-		wpVersion: compiled.versions.wp,
-		withICU: compiled.features.intl,
-		withNetworking: compiled.features.networking,
+		blueprint,
 		corsProxyUrl: corsProxy,
 		sqliteDriverVersion,
+		blueprintProgress: {
+			setProgress: ({ progress, caption }) => {
+				if (caption) {
+					blueprintProgress.setCaption(caption);
+				}
+				blueprintProgress.set(progress);
+			},
+			setLoaded: () => blueprintProgress.finish(),
+		},
+		onBlueprintStepCompleted,
+		onBeforeBlueprint,
 	});
 	await playground.isReady();
 	downloadPHPandWP.finish();
 
 	collectPhpLogs(logger, playground);
-	onClientConnected(playground);
 
-	if (onBeforeBlueprint) {
-		await onBeforeBlueprint();
-	}
-
-	await runBlueprintSteps(compiled, playground);
-	/**
-	 * Pre-fetch WordPress update checks to speed up the initial wp-admin load.
-	 *
-	 * @see https://github.com/WordPress/wordpress-playground/pull/2295
-	 */
-	if (compiled.features.networking) {
-		await playground.prefetchUpdateChecks();
-	}
 	progressTracker.finish();
 
 	return playground;

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -28,6 +28,7 @@ import {
 	hasCachedStaticFilesRemovedFromMinifiedBuild,
 } from './worker-utils';
 import { EmscriptenDownloadMonitor } from '@php-wasm/progress';
+import { ProgressTracker, type ProgressReceiver } from '@php-wasm/progress';
 import {
 	createMemoizedFetch,
 	RecommendedPHPVersion,
@@ -58,6 +59,13 @@ import {
 	intlDisabledFunctions,
 	networkingDisabledFunctions,
 } from './disabled-functions';
+import {
+	compileBlueprint,
+	runBlueprintSteps,
+	type Blueprint,
+	type OnStepCompleted,
+	type CompiledBlueprint,
+} from '@wp-playground/blueprints';
 import { WordPressFetchNetworkTransport } from './wordpress-fetch-network-transport';
 /* @ts-ignore */
 import { corsProxyUrl as defaultCorsProxyUrl } from 'virtual:cors-proxy-url';
@@ -83,11 +91,15 @@ export type WorkerBootOptions = {
 	phpVersion?: SupportedPHPVersion;
 	sapiName?: string;
 	scope: string;
-	withICU: boolean;
-	withNetworking: boolean;
+	withICU?: boolean;
+	withNetworking?: boolean;
 	mounts?: Array<MountDescriptor>;
 	shouldInstallWordPress?: boolean;
 	corsProxyUrl?: string;
+	blueprint?: Blueprint;
+	blueprintProgress?: ProgressReceiver;
+	onBlueprintStepCompleted?: OnStepCompleted;
+	onBeforeBlueprint?: () => Promise<void>;
 };
 
 /** @inheritDoc PHPClient */
@@ -178,14 +190,18 @@ export class PlaygroundWorkerEndpoint extends PHPWorker {
 	async boot({
 		scope,
 		mounts = [],
-		wpVersion = LatestMinifiedWordPressVersion,
+		wpVersion,
 		sqliteDriverVersion = LatestSqliteDriverVersion,
-		phpVersion = RecommendedPHPVersion,
+		phpVersion,
 		sapiName = 'cli',
-		withICU = false,
-		withNetworking = true,
+		withICU,
+		withNetworking,
 		shouldInstallWordPress = true,
 		corsProxyUrl,
+		blueprint,
+		blueprintProgress,
+		onBlueprintStepCompleted,
+		onBeforeBlueprint,
 	}: WorkerBootOptions) {
 		if (this.booted) {
 			throw new Error('Playground already booted');
@@ -194,9 +210,31 @@ export class PlaygroundWorkerEndpoint extends PHPWorker {
 		if (corsProxyUrl === undefined) {
 			corsProxyUrl = defaultCorsProxyUrl;
 		}
-
 		this.booted = true;
 		this.scope = scope;
+
+		let compiled: CompiledBlueprint | undefined;
+		if (blueprint) {
+			const progress = new ProgressTracker();
+			if (blueprintProgress) {
+				progress.pipe(blueprintProgress);
+			}
+			compiled = await compileBlueprint(blueprint, {
+				progress,
+				onStepCompleted: onBlueprintStepCompleted,
+				corsProxy: corsProxyUrl,
+			});
+			wpVersion = compiled.versions.wp;
+			phpVersion = compiled.versions.php;
+			withICU = compiled.features.intl;
+			withNetworking = compiled.features.networking;
+		}
+
+		wpVersion = wpVersion ?? LatestMinifiedWordPressVersion;
+		phpVersion = phpVersion ?? RecommendedPHPVersion;
+		withICU = withICU ?? false;
+		withNetworking = withNetworking ?? true;
+
 		this.requestedWordPressVersion = wpVersion;
 
 		wpVersion = MinifiedWordPressVersionsList.includes(wpVersion)
@@ -510,6 +548,16 @@ export class PlaygroundWorkerEndpoint extends PHPWorker {
 			}
 
 			setApiReady();
+
+			if (compiled) {
+				if (onBeforeBlueprint) {
+					await onBeforeBlueprint();
+				}
+				await runBlueprintSteps(compiled, this);
+				if (compiled.features.networking) {
+					await this.prefetchUpdateChecks();
+				}
+			}
 		} catch (e) {
 			setAPIError(e as Error);
 			throw e;


### PR DESCRIPTION
## Summary
- compile and run blueprints within `playground.boot` on the worker
- forward blueprint progress to the client and keep progress bar updates in sync

## Testing
- `npx nx run-many --target=test --projects=playground-client,playground-remote` *(fails: Failed to load url isomorphic-git/src/models/GitPktLine.js)*
- `npx nx run-many --target=lint --projects=playground-client,playground-remote`
- `npx nx run-many --target=typecheck --projects=playground-client,playground-remote`


------
https://chatgpt.com/codex/tasks/task_e_68c480e3e544832884d31f501cfe8408