### PR TITLE
Enhance FilePickerTree interactions

### DIFF
--- a/packages/playground/components/src/FilePickerTree/index.tsx
+++ b/packages/playground/components/src/FilePickerTree/index.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import {
 	__experimentalTreeGrid as TreeGrid,
 	__experimentalTreeGridRow as TreeGridRow,
@@ -24,9 +30,20 @@ export type FilePickerControlProps = {
 	onSelect?: (path: string) => void;
 	isLoading?: boolean;
 	error?: string;
+	onLoadChildren?: (path: string) => Promise<FileNode[]>;
+	onContextMenu?: (
+		event: React.MouseEvent,
+		node: FileNode,
+		path: string
+	) => void;
+	renamingPath?: string | null;
+	onRename?: (path: string, newName: string) => void;
+	onRenameCancel?: (path: string) => void;
 };
 
 type ExpandedNodePaths = Record<string, boolean>;
+
+type LoadedChildrenMap = Record<string, FileNode[]>;
 
 const FilePickerTree: React.FC<FilePickerControlProps> = ({
 	isLoading = false,
@@ -34,48 +51,208 @@ const FilePickerTree: React.FC<FilePickerControlProps> = ({
 	files,
 	initialPath,
 	onSelect = () => {},
+	onLoadChildren,
+	onContextMenu,
+	renamingPath = null,
+	onRename,
+	onRenameCancel,
 }) => {
 	const [expanded, setExpanded] = useState<ExpandedNodePaths>(() => {
 		if (!initialPath) {
 			return {};
 		}
-		const expanded: ExpandedNodePaths = {};
+		const initialExpanded: ExpandedNodePaths = {};
 		const pathParts = initialPath.split('/');
 		for (let i = 0; i < pathParts.length; i++) {
 			const pathSoFar = pathParts.slice(0, i + 1).join('/');
-			expanded[pathSoFar] = true;
+			initialExpanded[pathSoFar] = true;
 		}
-		return expanded;
+		return initialExpanded;
 	});
 	const [selectedPath, setSelectedPath] = useState<string | null>(() =>
 		initialPath ? initialPath : null
 	);
+	const [focusedPath, setFocusedPath] = useState<string | null>(() =>
+		initialPath ? initialPath : null
+	);
+	const [lazyChildren, setLazyChildren] = useState<LoadedChildrenMap>({});
+	const [loadingPaths, setLoadingPaths] = useState<Record<string, boolean>>(
+		{}
+	);
 
-	const expandNode = (path: string, isOpen: boolean) => {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const searchBufferTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+	const lazyChildrenRef = useRef(lazyChildren);
+	const loadingPathsRef = useRef(loadingPaths);
+
+	useEffect(() => {
+		lazyChildrenRef.current = lazyChildren;
+	}, [lazyChildren]);
+
+	useEffect(() => {
+		loadingPathsRef.current = loadingPaths;
+	}, [loadingPaths]);
+
+	const expandNode = useCallback((path: string, isOpen: boolean) => {
 		setExpanded((prevState) => ({
 			...prevState,
 			[path]: isOpen,
 		}));
-	};
+	}, []);
 
-	const selectPath = (path: string) => {
-		setSelectedPath(path);
-		onSelect(path);
-	};
+	const selectPath = useCallback(
+		(path: string) => {
+			setSelectedPath(path);
+			onSelect(path);
+		},
+		[onSelect]
+	);
 
-	const generatePath = (node: FileNode, parentPath = ''): string => {
-		return parentPath
-			? `${parentPath}/${node.name}`.replaceAll(/\/+/g, '/')
-			: node.name;
-	};
+	const focusPath = useCallback((path: string) => {
+		setFocusedPath(path);
+	}, []);
+
+	const generatePath = useCallback(
+		(node: FileNode, parentPath = ''): string => {
+			return parentPath
+				? `${parentPath}/${node.name}`.replaceAll(/\\+/g, '/')
+				: node.name;
+		},
+		[]
+	);
+
+	const getResolvedChildren = useCallback(
+		(node: FileNode, path: string): FileNode[] | undefined => {
+			if (node.children) {
+				return node.children;
+			}
+			return lazyChildrenRef.current[path];
+		},
+		[]
+	);
+
+	const loadChildrenForPath = useCallback(
+		async (path: string, node: FileNode) => {
+			if (!onLoadChildren || node.type !== 'folder') {
+				return;
+			}
+			const existingChildren =
+				node.children ?? lazyChildrenRef.current[path];
+			if (existingChildren || loadingPathsRef.current[path]) {
+				return existingChildren;
+			}
+			setLoadingPaths((prev) => ({
+				...prev,
+				[path]: true,
+			}));
+			try {
+				const children = await onLoadChildren(path);
+				setLazyChildren((prev) => ({
+					...prev,
+					[path]: children ?? [],
+				}));
+				return children;
+			} finally {
+				setLoadingPaths((prev) => {
+					const next = { ...prev };
+					delete next[path];
+					return next;
+				});
+			}
+		},
+		[onLoadChildren]
+	);
+
+	const handleToggleExpand = useCallback(
+		async (path: string, node: FileNode, isOpen: boolean) => {
+			expandNode(path, isOpen);
+			if (isOpen) {
+				await loadChildrenForPath(path, node);
+			}
+		},
+		[expandNode, loadChildrenForPath]
+	);
+
+	useEffect(() => {
+		if (!initialPath || !onLoadChildren) {
+			return;
+		}
+
+		let isMounted = true;
+		const loadInitialPath = async () => {
+			const segments = initialPath.split('/');
+			let currentChildren = files;
+			let accumulatedPath = '';
+			for (let i = 0; i < segments.length; i++) {
+				const segment = segments[i];
+				const nextNode = currentChildren?.find(
+					(child) => child.name === segment
+				);
+				if (!nextNode) {
+					break;
+				}
+				accumulatedPath = accumulatedPath
+					? `${accumulatedPath}/${segment}`
+					: segment;
+				if (nextNode.type !== 'folder') {
+					currentChildren = [];
+					continue;
+				}
+				const existingChildren =
+					nextNode.children ??
+					lazyChildrenRef.current[accumulatedPath];
+				if (!existingChildren && isMounted) {
+					const loaded = await loadChildrenForPath(
+						accumulatedPath,
+						nextNode
+					);
+					currentChildren = loaded ?? [];
+				} else {
+					currentChildren = existingChildren ?? [];
+				}
+			}
+		};
+
+		loadInitialPath();
+
+		return () => {
+			isMounted = false;
+		};
+	}, [initialPath, files, onLoadChildren, loadChildrenForPath]);
+
+	useEffect(() => {
+		if (!focusedPath) {
+			if (files.length > 0) {
+				const firstPath = generatePath(files[0]);
+				setFocusedPath(firstPath);
+			}
+			return;
+		}
+		if (renamingPath && renamingPath === focusedPath) {
+			return;
+		}
+		const focusTarget = containerRef.current?.querySelector(
+			`[data-path="${focusedPath}"]`
+		) as HTMLElement | null;
+		if (focusTarget && typeof focusTarget.focus === 'function') {
+			focusTarget.focus();
+		}
+	}, [files, focusedPath, generatePath, lazyChildren, renamingPath]);
+
+	useEffect(() => {
+		return () => {
+			if (searchBufferTimeoutRef.current) {
+				clearTimeout(searchBufferTimeoutRef.current);
+			}
+		};
+	}, []);
 
 	const [searchBuffer, setSearchBuffer] = useState('');
-	const searchBufferTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
 	function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
 		if (event.key.length === 1 && event.key.match(/\S/)) {
 			const newSearchBuffer = searchBuffer + event.key.toLowerCase();
 			setSearchBuffer(newSearchBuffer);
-			// Clear the buffer after 1 second
 			if (searchBufferTimeoutRef.current) {
 				clearTimeout(searchBufferTimeoutRef.current);
 			}
@@ -83,11 +260,9 @@ const FilePickerTree: React.FC<FilePickerControlProps> = ({
 				setSearchBuffer('');
 			}, 1000);
 
-			if (thisContainerRef.current) {
+			if (containerRef.current) {
 				const buttons = Array.from(
-					thisContainerRef.current.querySelectorAll(
-						'.file-node-button'
-					)
+					containerRef.current.querySelectorAll('.file-node-button')
 				);
 				const activeElement = document.activeElement;
 				let startIndex = 0;
@@ -101,42 +276,29 @@ const FilePickerTree: React.FC<FilePickerControlProps> = ({
 				}
 				for (let i = 0; i < buttons.length; i++) {
 					const index = (startIndex + i) % buttons.length;
-					const button = buttons[index];
+					const button = buttons[index] as HTMLElement;
 					if (
 						button.textContent
 							?.toLowerCase()
 							.trim()
 							.startsWith(newSearchBuffer)
 					) {
-						(button as HTMLButtonElement).focus();
+						button.focus();
+						const path = button.getAttribute('data-path');
+						if (path) {
+							focusPath(path);
+						}
 						break;
 					}
 				}
 			}
 		} else {
-			// Clear the buffer for any non-letter key press
 			setSearchBuffer('');
 			if (searchBufferTimeoutRef.current) {
 				clearTimeout(searchBufferTimeoutRef.current);
 			}
 		}
 	}
-
-	const thisContainerRef = useRef<HTMLDivElement>(null);
-
-	useEffect(() => {
-		// automatically focus the first button when the files are loaded
-		if (thisContainerRef.current) {
-			const firstButton = initialPath
-				? thisContainerRef.current.querySelector(
-						`[data-path="${initialPath}"]`
-				  )
-				: thisContainerRef.current.querySelector('.file-node-button');
-			if (firstButton) {
-				(firstButton as HTMLButtonElement).focus();
-			}
-		}
-	}, [files.length > 0]);
 
 	if (isLoading) {
 		return (
@@ -156,7 +318,7 @@ const FilePickerTree: React.FC<FilePickerControlProps> = ({
 	}
 
 	return (
-		<div onKeyDown={handleKeyDown} ref={thisContainerRef}>
+		<div onKeyDown={handleKeyDown} ref={containerRef}>
 			<TreeGrid className={css['filePickerTree']}>
 				{files.map((file, index) => (
 					<NodeRow
@@ -166,10 +328,18 @@ const FilePickerTree: React.FC<FilePickerControlProps> = ({
 						position={index + 1}
 						setSize={files.length}
 						expandedNodePaths={expanded}
-						expandNode={expandNode}
+						expandNode={handleToggleExpand}
 						selectedNode={selectedPath}
+						focusedNode={focusedPath}
 						selectPath={selectPath}
+						focusPath={focusPath}
 						generatePath={generatePath}
+						getChildren={getResolvedChildren}
+						loadingPaths={loadingPaths}
+						onContextMenu={onContextMenu}
+						renamingPath={renamingPath}
+						onRename={onRename}
+						onRenameCancel={onRenameCancel}
 					/>
 				))}
 			</TreeGrid>
@@ -183,12 +353,27 @@ const NodeRow: React.FC<{
 	position: number;
 	setSize: number;
 	expandedNodePaths: ExpandedNodePaths;
-	expandNode: (path: string, isOpen: boolean) => void;
+	expandNode: (
+		path: string,
+		node: FileNode,
+		isOpen: boolean
+	) => void | Promise<void>;
 	selectPath: (path: string) => void;
 	selectedNode: string | null;
+	focusPath: (path: string) => void;
+	focusedNode: string | null;
 	generatePath: (node: FileNode, parentPath?: string) => string;
+	getChildren: (node: FileNode, path: string) => FileNode[] | undefined;
+	loadingPaths: Record<string, boolean>;
+	onContextMenu?: (
+		event: React.MouseEvent,
+		node: FileNode,
+		path: string
+	) => void;
+	renamingPath: string | null;
+	onRename?: (path: string, newName: string) => void;
+	onRenameCancel?: (path: string) => void;
 	parentPath?: string;
-	parentMapping?: string;
 }> = ({
 	node,
 	level,
@@ -197,16 +382,54 @@ const NodeRow: React.FC<{
 	expandedNodePaths,
 	expandNode,
 	selectPath,
-	generatePath,
-	parentPath = '',
 	selectedNode,
+	focusPath,
+	focusedNode,
+	generatePath,
+	getChildren,
+	loadingPaths,
+	onContextMenu,
+	renamingPath,
+	onRename,
+	onRenameCancel,
+	parentPath = '',
 }) => {
 	const path = generatePath(node, parentPath);
 	const isExpanded = expandedNodePaths[path];
+	const isRenaming = renamingPath === path;
+	const renameInputRef = useRef<HTMLInputElement>(null);
+	const [renameValue, setRenameValue] = useState(node.name);
+	const renameHandledRef = useRef(false);
 
-	const toggleOpen = () => expandNode(path, !isExpanded);
+	const resolvedChildren = useMemo(
+		() => getChildren(node, path) ?? [],
+		[getChildren, node, path]
+	);
+	const isLoadingChildren = Boolean(loadingPaths[path]);
 
-	const handleKeyDown = (event: any) => {
+	useEffect(() => {
+		if (isRenaming) {
+			setRenameValue(node.name);
+			renameHandledRef.current = false;
+			if (typeof window !== 'undefined' && window.requestAnimationFrame) {
+				window.requestAnimationFrame(() => {
+					renameInputRef.current?.select();
+				});
+			} else {
+				renameInputRef.current?.select();
+			}
+		} else {
+			renameHandledRef.current = false;
+		}
+	}, [isRenaming, node.name]);
+
+	const toggleOpen = () => {
+		if (node.type === 'folder') {
+			expandNode(path, node, !isExpanded);
+		}
+	};
+
+	const handleKeyDown = (event: React.KeyboardEvent) => {
 		if (event.key === 'ArrowLeft') {
 			if (isExpanded) {
 				toggleOpen();
@@ -221,8 +444,11 @@ const NodeRow: React.FC<{
 			event.stopPropagation();
 		} else if (event.key === 'ArrowRight') {
 			if (isExpanded) {
-				if (node.children?.length) {
-					const firstChildPath = generatePath(node.children[0], path);
+				if (resolvedChildren?.length) {
+					const firstChildPath = generatePath(
+						resolvedChildren[0],
+						path
+					);
 					(
 						document.querySelector(
 							`[data-path="${firstChildPath}"]`
@@ -234,10 +460,19 @@ const NodeRow: React.FC<{
 			}
 			event.preventDefault();
 			event.stopPropagation();
-		} else if (event.key === 'Space') {
-			expandNode(path, !isExpanded);
+		} else if (
+			event.key === ' ' ||
+			event.key === 'Space' ||
+			event.key === 'Spacebar'
+		) {
+			if (node.type === 'folder') {
+				expandNode(path, node, !isExpanded);
+			}
+			event.preventDefault();
 		} else if (event.key === 'Enter') {
-			const form = event.currentTarget?.closest('form');
+			selectPath(path);
+			focusPath(path);
+			const form = (event.currentTarget as HTMLElement)?.closest('form');
 			if (form) {
 				setTimeout(() => {
 					form.dispatchEvent(new Event('submit', { bubbles: true }));
@@ -245,6 +480,35 @@ const NodeRow: React.FC<{
 			}
 		}
 	};
+
+	const handleContextMenu = (event: React.MouseEvent) => {
+		onContextMenu?.(event, node, path);
+	};
+
+	const handleRenameSubmit = (event: React.FormEvent) => {
+		event.preventDefault();
+		renameHandledRef.current = true;
+		onRename?.(path, renameValue.trim());
+	};
+
+	const handleRenameKeyDown = (
+		event: React.KeyboardEvent<HTMLInputElement>
+	) => {
+		if (event.key === 'Escape') {
+			event.preventDefault();
+			event.stopPropagation();
+			renameHandledRef.current = true;
+			onRenameCancel?.(path);
+		}
+	};
+
+	const handleRenameBlur = () => {
+		if (!renameHandledRef.current) {
+			onRenameCancel?.(path);
+		}
+		renameHandledRef.current = false;
+	};
+
 	return (
 		<>
 			<TreeGridRow
@@ -254,44 +518,106 @@ const NodeRow: React.FC<{
 			>
 				<TreeGridCell>
 					{() => (
-						<Button
-							onClick={() => {
-								toggleOpen();
-								selectPath(path);
-							}}
-							onKeyDown={handleKeyDown}
-							onFocus={() => {
-								selectPath(path);
-							}}
-							className={classNames(css['fileNodeButton'], {
-								[css['selected']]: selectedNode === path,
-								'file-node-button': true,
-							})}
-							data-path={path}
-						>
-							<FileName
-								node={node}
-								isOpen={node.type === 'folder' && isExpanded}
-								level={level}
-							/>
-						</Button>
+						<>
+							{isRenaming ? (
+								<form
+									onSubmit={handleRenameSubmit}
+									className={classNames(
+										css['fileNodeButton'],
+										css['renaming'],
+										'file-node-button',
+										{
+											[css['selected']]:
+												selectedNode === path,
+											[css['focused']]:
+												focusedNode === path,
+										}
+									)}
+									data-path={path}
+									onContextMenu={handleContextMenu}
+								>
+									<FileName
+										node={node}
+										isOpen={
+											node.type === 'folder' && isExpanded
+										}
+										level={level}
+										isLoading={isLoadingChildren}
+										hideName
+									/>
+									<input
+										ref={renameInputRef}
+										className={css['renameInput']}
+										value={renameValue}
+										onChange={(event) =>
+											setRenameValue(event.target.value)
+										}
+										onBlur={handleRenameBlur}
+										onFocus={() => focusPath(path)}
+										onKeyDown={handleRenameKeyDown}
+									/>
+								</form>
+							) : (
+								<Button
+									onClick={() => {
+										if (node.type === 'folder') {
+											toggleOpen();
+										}
+										selectPath(path);
+										focusPath(path);
+									}}
+									onKeyDown={handleKeyDown}
+									onFocus={() => {
+										focusPath(path);
+									}}
+									onContextMenu={handleContextMenu}
+									className={classNames(
+										css['fileNodeButton'],
+										{
+											[css['selected']]:
+												selectedNode === path,
+											[css['focused']]:
+												focusedNode === path,
+										}
+									)}
+									data-path={path}
+								>
+									<FileName
+										node={node}
+										isOpen={
+											node.type === 'folder' && isExpanded
+										}
+										level={level}
+										isLoading={isLoadingChildren}
+									/>
+								</Button>
+							)}
+						</>
 					)}
 				</TreeGridCell>
 			</TreeGridRow>
 			{isExpanded &&
-				node.children &&
-				node.children.map((child, index) => (
+				resolvedChildren &&
+				resolvedChildren.map((child, index) => (
 					<NodeRow
 						key={child.name}
 						node={child}
 						level={level + 1}
 						position={index + 1}
-						setSize={node.children!.length}
+						setSize={resolvedChildren.length}
 						expandedNodePaths={expandedNodePaths}
 						expandNode={expandNode}
-						selectedNode={selectedNode}
 						selectPath={selectPath}
+						selectedNode={selectedNode}
+						focusPath={focusPath}
+						focusedNode={focusedNode}
 						generatePath={generatePath}
+						getChildren={getChildren}
+						loadingPaths={loadingPaths}
+						onContextMenu={onContextMenu}
+						renamingPath={renamingPath}
+						onRename={onRename}
+						onRenameCancel={onRenameCancel}
 						parentPath={path}
 					/>
 				))}
@@ -303,7 +629,9 @@ const FileName: React.FC<{
 	node: FileNode;
 	level: number;
 	isOpen?: boolean;
-}> = ({ node, level, isOpen }) => {
+	isLoading?: boolean;
+	hideName?: boolean;
+}> = ({ node, level, isOpen, isLoading = false, hideName = false }) => {
 	const indent: string[] = [];
 	for (let i = 0; i < level; i++) {
 		indent.push('&nbsp;&nbsp;&nbsp;&nbsp;');
@@ -320,7 +648,8 @@ const FileName: React.FC<{
 				<div style={{ width: 16 }}>&nbsp;</div>
 			)}
 			<Icon width={16} icon={node.type === 'folder' ? folder : file} />
-			<span className={css['fileName']}>{node.name}</span>
+			{isLoading && <Spinner className={css['inlineSpinner']} />}
+			{!hideName && <span className={css['fileName']}>{node.name}</span>}
 		</>
 	);
 };

--- a/packages/playground/components/src/FilePickerTree/style.module.css
+++ b/packages/playground/components/src/FilePickerTree/style.module.css
@@ -43,13 +43,41 @@
 	font-size: 13px;
 	font-weight: 400;
 
-	&:focus,
-	.selected {
-		background-color: var(--wp-admin-theme-color);
-		color: #fff;
+	&:focus {
 		outline: 0 !important;
 		box-shadow: none !important;
 	}
+}
+
+.selected {
+	background-color: var(--wp-admin-theme-color);
+	color: #fff;
+}
+
+.focused {
+	box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
+	border-radius: 2px;
+}
+
+.renaming {
+	align-items: center;
+	gap: 8px;
+}
+
+.rename-input,
+.renameInput {
+	flex: 1;
+	border: 1px solid #ccc;
+	border-radius: 2px;
+	padding: 4px 6px;
+	font-size: 13px;
+	font-family: inherit;
+}
+
+.inline-spinner :global(.components-spinner__outer),
+.inlineSpinner :global(.components-spinner__outer) {
+	width: 16px;
+	height: 16px;
 }
 
 .file-name {


### PR DESCRIPTION
## Summary
- separate focus and selection handling in the file tree and expose a context menu hook for consumers
- add lazy loading support for folders, including automatic loading for initial paths
- implement a controlled rename mode with callback notifications and update styles for focus/rename states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d87242963c8328abfe60e17b3fa3c4