### PR TITLE
Improve sidebar selected state visibility

### DIFF
--- a/packages/playground/website/src/components/site-manager/sidebar/style.module.css
+++ b/packages/playground/website/src/components/site-manager/sidebar/style.module.css
@@ -48,17 +48,34 @@
 	line-height: 20px;
 	color: var(--site-manager-text-color) !important;
 	text-align: left;
-	border-radius: 4px;
+	border-radius: 6px;
 	margin-bottom: 2px;
+	border: 1px solid transparent;
+	transition: background-color 0.2s ease, border-color 0.2s ease,
+		box-shadow 0.2s ease, color 0.2s ease;
 }
 .sidebar-item:hover,
-.sidebar-item--selected {
+.sidebar-item:focus-visible {
 	color: var(--site-manager-text-color) !important;
 	background-color: #353535;
+	border-color: rgba(114, 174, 230, 0.35);
+}
+
+.sidebar-item:focus-visible {
+	outline: none;
+	box-shadow: 0 0 0 2px rgba(114, 174, 230, 0.35);
+}
+
+.sidebar-item--selected {
+	color: var(--site-manager-text-color) !important;
+	font-weight: 600;
+	background-color: rgba(114, 174, 230, 0.18);
+	border-color: #72aee6;
+	box-shadow: 0 0 0 1px rgba(114, 174, 230, 0.5) inset;
 }
 
 .sidebar-item--selected:hover {
-	background-color: #545454;
+	background-color: rgba(114, 174, 230, 0.28);
 }
 
 .sidebar-list-item--logo {


### PR DESCRIPTION
## Summary
- refresh the site manager sidebar selection styles to include a clearer accent border and background
- add focus-visible feedback so keyboard navigation matches the hover styling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f177f4c87083289afa19b4e0a904f2