### PR TITLE
Add Node DNS-backed gethostbyname for PHP wasm builds

### DIFF
--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -539,6 +539,7 @@ RUN cp -v /root/php-src/.libs/libphp*.la /root/lib/libphp.la
 RUN cp -v /root/php-src/.libs/libphp*.a /root/lib/libphp.a
 
 COPY ./php/php_wasm.c /root/
+COPY ./php/gethostbyname-node.c /root/
 COPY ./php/proc_open* /root/
 
 RUN if [[ "${PHP_VERSION:0:1}" -le "7" && "${PHP_VERSION:2:1}" -le "3" ]]; then \
@@ -554,10 +555,10 @@ ARG OUTPUT_DIR_ON_HOST
 ARG DEBUG_DWARF_COMPILATION_DIR
 ARG WITH_DEBUG
 RUN set -euxo pipefail; \
-	if [ "$EMSCRIPTEN_ENVIRONMENT" = "node" ]; then \
-		# Add nodefs when building for node.js
-		echo -n ' -lnodefs.js ' >> /root/.emcc-php-wasm-flags; \
-	fi; \
+        if [ "$EMSCRIPTEN_ENVIRONMENT" = "node" ]; then \
+                # Add nodefs when building for node.js
+                echo -n ' -lnodefs.js -DPHP_WASM_USE_NODE_DNS ' >> /root/.emcc-php-wasm-flags; \
+        fi; \
 	if [ "${WITH_SOURCEMAPS}" = "yes" ] || [ "${WITH_DEBUG}" = "yes" ]; then \
 		echo -n ' -g3 ' >> /root/.emcc-php-wasm-flags; \
 		# Make source file paths relative to the location of the .wasm file
@@ -2198,13 +2199,14 @@ RUN set -euxo pipefail; \
 	-s INVOKE_RUN=0 \
 	-o /build/output/php.js \
 	-s EXIT_RUNTIME=1 \
-	-Wl,--wrap=select \
-	-Wl,--wrap=usleep \
-		/root/lib/libphp.a \
-		/root/proc_open.c \
-		/root/php_wasm.c \
-		$(cat /root/.emcc-php-wasm-sources) \
-	-s ENVIRONMENT=$EMSCRIPTEN_ENVIRONMENT \
+        -Wl,--wrap=select \
+        -Wl,--wrap=usleep \
+                /root/lib/libphp.a \
+                /root/proc_open.c \
+                /root/php_wasm.c \
+                /root/gethostbyname-node.c \
+                $(cat /root/.emcc-php-wasm-sources) \
+        -s ENVIRONMENT=$EMSCRIPTEN_ENVIRONMENT \
 	-s FORCE_FILESYSTEM=1 \
 	-s EXPORT_NAME="'PHPLoader'"
 	# Emscripten complains it can't find some Asyncify functions

--- a/packages/php-wasm/compile/php/gethostbyname-node.c
+++ b/packages/php-wasm/compile/php/gethostbyname-node.c
@@ -1,0 +1,86 @@
+#ifdef PHP_WASM_USE_NODE_DNS
+
+/*
+ * Provide a Node-backed gethostbyname() that resolves hostnames using the
+ * native dns module instead of Emscripten's synthetic DNS mapping. This is
+ * enabled only for the Node build via PHP_WASM_USE_NODE_DNS.
+ */
+
+#include <arpa/inet.h>
+#include <emscripten.h>
+#include <netdb.h>
+#include <string.h>
+
+#  ifdef PLAYGROUND_JSPI
+EM_ASYNC_JS(int, wasm_node_dns_lookup, (const char *name, char *out, int out_len), {
+        const returnCallback = (resolver) => new Promise(resolver);
+#  else
+EM_JS(int, wasm_node_dns_lookup, (const char *name, char *out, int out_len), {
+        const returnCallback = (resolver) => Asyncify.handleSleep(resolver);
+#  endif
+        return returnCallback(async (wakeUp) => {
+                try {
+                        const dns = require('dns').promises;
+                        const host = UTF8ToString(name);
+                        const { address } = await dns.lookup(host, { family: 4 });
+                        const required = lengthBytesUTF8(address) + 1;
+                        if (required > out_len) {
+                                wakeUp(-required);
+                                return;
+                        }
+                        stringToUTF8(address, out, out_len);
+                        wakeUp(required);
+                } catch (e) {
+                        wakeUp(0);
+                }
+        });
+});
+
+static struct hostent *node_dns_gethostbyname(const char *name)
+{
+        static struct hostent h;
+        static char *aliases[1];
+        static char *addr_list[2];
+        static struct in_addr addr;
+        static char name_buf[256];
+
+        memset(&h, 0, sizeof(h));
+        aliases[0] = NULL;
+        addr_list[0] = NULL;
+        addr_list[1] = NULL;
+
+        char ip[64];
+        int n = wasm_node_dns_lookup(name, ip, sizeof(ip));
+        if (n <= 0) {
+#ifdef h_errno
+                h_errno = HOST_NOT_FOUND;
+#endif
+                return NULL;
+        }
+
+        if (!inet_aton(ip, &addr)) {
+#ifdef h_errno
+                h_errno = NO_RECOVERY;
+#endif
+                return NULL;
+        }
+
+        strncpy(name_buf, name, sizeof(name_buf) - 1);
+        name_buf[sizeof(name_buf) - 1] = '\0';
+
+        h.h_name = name_buf;
+        h.h_aliases = aliases;
+        h.h_addrtype = AF_INET;
+        h.h_length = sizeof(struct in_addr);
+        addr_list[0] = (char *)&addr;
+        h.h_addr_list = addr_list;
+
+        return &h;
+}
+
+struct hostent *gethostbyname(const char *name)
+{
+        return node_dns_gethostbyname(name);
+}
+
+#endif


### PR DESCRIPTION
## Summary
- add a Node-only gethostbyname implementation that resolves hostnames via the native dns module using Asyncify/JSPI helpers
- include the override in the PHP wasm build pipeline and enable it for node targets via compiler flags

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931be45c2b483289c05ef7ba97b0361)