### PR TITLE
Add mock SMTP server to capture outgoing emails

### DIFF
--- a/packages/php-wasm/web/src/lib/index.ts
+++ b/packages/php-wasm/web/src/lib/index.ts
@@ -14,6 +14,7 @@ export type {
 } from './directory-handle-mount';
 
 export * from './tls/certificates';
+export * from './smtp';
 export type { TCPOverFetchOptions } from './tcp-over-fetch-websocket';
 export { fetchWithCorsProxy } from './fetch-with-cors-proxy';
 export {

--- a/packages/php-wasm/web/src/lib/smtp/index.ts
+++ b/packages/php-wasm/web/src/lib/smtp/index.ts
@@ -1,0 +1,8 @@
+export {
+	MockSMTPServer,
+	capturedEmails,
+	clearCapturedEmails,
+	isSMTPPort,
+	SMTP_PORTS,
+	type CapturedEmail,
+} from './mock-smtp-server';

--- a/packages/php-wasm/web/src/lib/smtp/mock-smtp-server.ts
+++ b/packages/php-wasm/web/src/lib/smtp/mock-smtp-server.ts
@@ -1,0 +1,303 @@
+/**
+ * Mock SMTP server that intercepts outgoing emails from PHP.
+ *
+ * This module implements a basic SMTP server that accepts email submissions
+ * and stores them in an array for later inspection. It's designed to work
+ * similarly to the TLS interception - intercepting SMTP traffic and handling
+ * it locally instead of forwarding to an actual mail server.
+ *
+ * ## Supported SMTP Commands:
+ * - EHLO/HELO: Server greeting
+ * - AUTH: Authentication (accepts any credentials)
+ * - MAIL FROM: Sender address
+ * - RCPT TO: Recipient address(es)
+ * - DATA: Email body (terminated by \r\n.\r\n)
+ * - QUIT: Close connection
+ * - RSET: Reset transaction
+ * - NOOP: No operation
+ *
+ * ## Usage:
+ * The captured emails are stored in the `capturedEmails` array exported
+ * from this module. Each email contains the sender, recipients, and raw
+ * email data.
+ */
+
+export interface CapturedEmail {
+	from: string;
+	to: string[];
+	data: string;
+	timestamp: Date;
+}
+
+/**
+ * Array storing all captured emails.
+ * This is the main way to access intercepted emails.
+ */
+export const capturedEmails: CapturedEmail[] = [];
+
+/**
+ * Clear all captured emails.
+ */
+export function clearCapturedEmails(): void {
+	capturedEmails.length = 0;
+}
+
+type SMTPState =
+	| 'INIT'
+	| 'GREETING_SENT'
+	| 'READY'
+	| 'MAIL_FROM'
+	| 'RCPT_TO'
+	| 'DATA'
+	| 'QUIT';
+
+const SMTP_RESPONSES = {
+	GREETING: '220 playground.wordpress.net ESMTP Mock SMTP Server\r\n',
+	EHLO_RESPONSE: (domain: string) =>
+		`250-playground.wordpress.net Hello ${domain}\r\n` +
+		'250-SIZE 35882577\r\n' +
+		'250-8BITMIME\r\n' +
+		'250-AUTH PLAIN LOGIN\r\n' +
+		'250 OK\r\n',
+	HELO_RESPONSE: '250 playground.wordpress.net\r\n',
+	OK: '250 OK\r\n',
+	AUTH_OK: '235 2.7.0 Authentication successful\r\n',
+	AUTH_CONTINUE: '334 \r\n',
+	DATA_START: '354 Start mail input; end with <CRLF>.<CRLF>\r\n',
+	QUIT: '221 Bye\r\n',
+	ERROR_SYNTAX: '500 Syntax error, command unrecognized\r\n',
+	ERROR_SEQUENCE: '503 Bad sequence of commands\r\n',
+	ERROR_AUTH: '535 Authentication failed\r\n',
+};
+
+/**
+ * Mock SMTP server session handler.
+ * Creates a bidirectional stream pair for handling SMTP communication.
+ */
+export class MockSMTPServer {
+	private state: SMTPState = 'INIT';
+	private currentEmail: Partial<CapturedEmail> = {};
+	private dataBuffer = '';
+	private inputBuffer = '';
+	private authState: 'none' | 'waiting_username' | 'waiting_password' =
+		'none';
+
+	private writer: WritableStreamDefaultWriter<Uint8Array>;
+	private encoder = new TextEncoder();
+	private decoder = new TextDecoder();
+
+	/**
+	 * Upstream: data from the client (PHP) to the server
+	 * Downstream: data from the server to the client (PHP)
+	 */
+	public clientUpstream = new TransformStream<Uint8Array, Uint8Array>();
+	public clientDownstream = new TransformStream<Uint8Array, Uint8Array>();
+
+	constructor() {
+		this.writer = this.clientDownstream.writable.getWriter();
+		this.startProcessing();
+	}
+
+	private async startProcessing() {
+		// Send greeting immediately
+		await this.sendResponse(SMTP_RESPONSES.GREETING);
+		this.state = 'GREETING_SENT';
+
+		// Process incoming data
+		const reader = this.clientUpstream.readable.getReader();
+
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) {
+					break;
+				}
+
+				// Add to input buffer and process complete lines
+				this.inputBuffer += this.decoder.decode(value);
+				await this.processInputBuffer();
+			}
+		} catch (error) {
+			// Connection closed or error
+		} finally {
+			reader.releaseLock();
+			try {
+				await this.writer.close();
+			} catch {
+				// Writer may already be closed
+			}
+		}
+	}
+
+	private async processInputBuffer() {
+		if (this.state === 'DATA') {
+			// In DATA mode, look for the terminator \r\n.\r\n
+			const endIndex = this.inputBuffer.indexOf('\r\n.\r\n');
+			if (endIndex !== -1) {
+				// Extract the email data (without the terminator)
+				this.dataBuffer += this.inputBuffer.slice(0, endIndex);
+				this.inputBuffer = this.inputBuffer.slice(endIndex + 5); // Skip \r\n.\r\n
+
+				// Store the captured email
+				this.currentEmail.data = this.dataBuffer;
+				this.currentEmail.timestamp = new Date();
+				capturedEmails.push(this.currentEmail as CapturedEmail);
+
+				// Reset for next email
+				this.currentEmail = {};
+				this.dataBuffer = '';
+				this.state = 'READY';
+
+				await this.sendResponse(SMTP_RESPONSES.OK);
+
+				// Process any remaining commands in the buffer
+				await this.processInputBuffer();
+			} else {
+				// More data to come, buffer it
+				// Keep last 4 chars in inputBuffer in case terminator is split
+				if (this.inputBuffer.length > 4) {
+					this.dataBuffer += this.inputBuffer.slice(0, -4);
+					this.inputBuffer = this.inputBuffer.slice(-4);
+				}
+			}
+			return;
+		}
+
+		// Process line by line for commands
+		let lineEndIndex: number;
+		while ((lineEndIndex = this.inputBuffer.indexOf('\r\n')) !== -1) {
+			const line = this.inputBuffer.slice(0, lineEndIndex);
+			this.inputBuffer = this.inputBuffer.slice(lineEndIndex + 2);
+			await this.processCommand(line);
+		}
+	}
+
+	private async processCommand(line: string) {
+		const upperLine = line.toUpperCase();
+
+		// Handle AUTH continuation
+		if (this.authState !== 'none') {
+			if (this.authState === 'waiting_username') {
+				// Username received (base64 encoded)
+				this.authState = 'waiting_password';
+				await this.sendResponse(SMTP_RESPONSES.AUTH_CONTINUE);
+				return;
+			} else if (this.authState === 'waiting_password') {
+				// Password received (base64 encoded) - accept anything
+				this.authState = 'none';
+				await this.sendResponse(SMTP_RESPONSES.AUTH_OK);
+				return;
+			}
+		}
+
+		if (upperLine.startsWith('EHLO ')) {
+			const domain = line.slice(5).trim();
+			this.state = 'READY';
+			await this.sendResponse(SMTP_RESPONSES.EHLO_RESPONSE(domain));
+		} else if (upperLine.startsWith('HELO ')) {
+			this.state = 'READY';
+			await this.sendResponse(SMTP_RESPONSES.HELO_RESPONSE);
+		} else if (upperLine.startsWith('AUTH ')) {
+			if (this.state !== 'READY') {
+				await this.sendResponse(SMTP_RESPONSES.ERROR_SEQUENCE);
+				return;
+			}
+
+			const authType = line.slice(5).trim().toUpperCase();
+			if (authType.startsWith('PLAIN ')) {
+				// AUTH PLAIN with credentials inline - accept immediately
+				await this.sendResponse(SMTP_RESPONSES.AUTH_OK);
+			} else if (authType === 'PLAIN' || authType === 'LOGIN') {
+				// Need to receive credentials
+				this.authState = 'waiting_username';
+				await this.sendResponse(SMTP_RESPONSES.AUTH_CONTINUE);
+			} else {
+				await this.sendResponse(SMTP_RESPONSES.AUTH_OK);
+			}
+		} else if (upperLine.startsWith('MAIL FROM:')) {
+			if (this.state !== 'READY') {
+				await this.sendResponse(SMTP_RESPONSES.ERROR_SEQUENCE);
+				return;
+			}
+
+			const from = this.extractEmailAddress(line.slice(10));
+			this.currentEmail = { from, to: [] };
+			this.state = 'MAIL_FROM';
+			await this.sendResponse(SMTP_RESPONSES.OK);
+		} else if (upperLine.startsWith('RCPT TO:')) {
+			if (this.state !== 'MAIL_FROM' && this.state !== 'RCPT_TO') {
+				await this.sendResponse(SMTP_RESPONSES.ERROR_SEQUENCE);
+				return;
+			}
+
+			const to = this.extractEmailAddress(line.slice(8));
+			this.currentEmail.to = this.currentEmail.to || [];
+			this.currentEmail.to.push(to);
+			this.state = 'RCPT_TO';
+			await this.sendResponse(SMTP_RESPONSES.OK);
+		} else if (upperLine === 'DATA') {
+			if (this.state !== 'RCPT_TO') {
+				await this.sendResponse(SMTP_RESPONSES.ERROR_SEQUENCE);
+				return;
+			}
+
+			this.state = 'DATA';
+			this.dataBuffer = '';
+			await this.sendResponse(SMTP_RESPONSES.DATA_START);
+		} else if (upperLine === 'QUIT') {
+			this.state = 'QUIT';
+			await this.sendResponse(SMTP_RESPONSES.QUIT);
+			try {
+				await this.writer.close();
+			} catch {
+				// Already closed
+			}
+		} else if (upperLine === 'RSET') {
+			this.currentEmail = {};
+			this.dataBuffer = '';
+			this.state = 'READY';
+			await this.sendResponse(SMTP_RESPONSES.OK);
+		} else if (upperLine === 'NOOP') {
+			await this.sendResponse(SMTP_RESPONSES.OK);
+		} else if (upperLine === 'STARTTLS') {
+			// We don't actually support STARTTLS upgrade, but we can accept it
+			// The TLS layer is handled separately in tcp-over-fetch-websocket
+			await this.sendResponse('220 Ready to start TLS\r\n');
+		} else {
+			// Unknown command
+			await this.sendResponse(SMTP_RESPONSES.ERROR_SYNTAX);
+		}
+	}
+
+	private extractEmailAddress(input: string): string {
+		// Extract email from formats like <email@example.com> or email@example.com
+		const match = input.match(/<([^>]+)>/);
+		if (match) {
+			return match[1].trim();
+		}
+		return input.trim();
+	}
+
+	private async sendResponse(response: string) {
+		try {
+			await this.writer.write(this.encoder.encode(response));
+		} catch {
+			// Writer closed
+		}
+	}
+}
+
+/**
+ * Standard SMTP ports.
+ * - 25: Standard SMTP (plaintext or STARTTLS)
+ * - 465: SMTPS (implicit TLS)
+ * - 587: Submission (typically STARTTLS)
+ */
+export const SMTP_PORTS = [25, 465, 587];
+
+/**
+ * Check if a given port is an SMTP port.
+ */
+export function isSMTPPort(port: number): boolean {
+	return SMTP_PORTS.includes(port);
+}

--- a/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
+++ b/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
@@ -46,6 +46,7 @@ import { fetchWithCorsProxy } from './fetch-with-cors-proxy';
 import { ChunkedDecoderStream } from './chunked-decoder';
 import type { EmscriptenOptions } from '@php-wasm/universal';
 import { concatUint8Arrays } from '@php-wasm/util';
+import { MockSMTPServer, isSMTPPort } from './smtp/mock-smtp-server';
 
 export type TCPOverFetchOptions = {
 	CAroot: GeneratedCertificate;
@@ -274,6 +275,14 @@ export class TCPOverFetchWebsocket {
 				this.fetchOverHTTP();
 				this.fetchInitiated = true;
 				break;
+			case 'smtp':
+				this.handleSMTP();
+				this.fetchInitiated = true;
+				break;
+			case 'smtp-tls':
+				this.handleSMTPOverTLS();
+				this.fetchInitiated = true;
+				break;
 		}
 	}
 
@@ -364,6 +373,92 @@ export class TCPOverFetchWebsocket {
 		}
 	}
 
+	/**
+	 * Handle plaintext SMTP connections (ports 25, 587).
+	 * Creates a mock SMTP server that captures outgoing emails.
+	 */
+	async handleSMTP() {
+		const smtpServer = new MockSMTPServer();
+
+		// Connect this WebSocket's client end to the SMTP server.
+		// Forward the data from PHP to the mock SMTP server.
+		this.clientUpstream.readable
+			.pipeTo(smtpServer.clientUpstream.writable)
+			.catch(() => {
+				// Ignore failures arising from pipeTo() errors.
+			});
+
+		// Forward the SMTP responses back to PHP.
+		smtpServer.clientDownstream.readable
+			.pipeTo(this.clientDownstream.writable)
+			.catch(() => {
+				// Ignore failures arising from pipeTo() errors.
+			});
+	}
+
+	/**
+	 * Handle SMTPS (implicit TLS) connections on port 465.
+	 * Performs TLS handshake first, then routes to mock SMTP server.
+	 */
+	async handleSMTPOverTLS() {
+		if (!this.CAroot) {
+			throw new Error(
+				'TLS protocol is only supported when the TCPOverFetchWebsocket is ' +
+					'instantiated with a CAroot'
+			);
+		}
+		const siteCert = await generateCertificate(
+			{
+				subject: {
+					commonName: this.host,
+					organizationName: this.host,
+					countryName: 'US',
+				},
+				issuer: this.CAroot.tbsDescription.subject,
+			},
+			this.CAroot.keyPair
+		);
+
+		const tlsConnection = new TLS_1_2_Connection();
+
+		// Connect this WebSocket's client end to the TLS connection.
+		// Forward the encrypted bytes from the WebSocket to the TLS connection.
+		this.clientUpstream.readable
+			.pipeTo(tlsConnection.clientEnd.upstream.writable)
+			.catch(() => {
+				// Ignore failures arising from pipeTo() errors.
+			});
+
+		// Forward the encrypted bytes from the TLS connection to this WebSocket.
+		tlsConnection.clientEnd.downstream.readable
+			.pipeTo(this.clientDownstream.writable)
+			.catch(() => {
+				// Ignore failures arising from pipeTo() errors.
+			});
+
+		// Perform the TLS handshake
+		await tlsConnection.TLSHandshake(siteCert.keyPair.privateKey, [
+			siteCert.certificate,
+			this.CAroot.certificate,
+		]);
+
+		// Create mock SMTP server for the decrypted traffic
+		const smtpServer = new MockSMTPServer();
+
+		// Connect the TLS server end to the mock SMTP server
+		tlsConnection.serverEnd.upstream.readable
+			.pipeTo(smtpServer.clientUpstream.writable)
+			.catch(() => {
+				// Ignore failures
+			});
+
+		smtpServer.clientDownstream.readable
+			.pipeTo(tlsConnection.serverEnd.downstream.writable)
+			.catch(() => {
+				// Ignore failures
+			});
+	}
+
 	close() {
 		/**
 		 * Workaround a PHP.wasm issue – if the WebSocket is
@@ -402,6 +497,19 @@ function guessProtocol(port: number, data: Uint8Array) {
 		return false;
 	}
 
+	// Check for SMTPS (implicit TLS on port 465)
+	// Must check this before general TLS detection
+	if (port === 465) {
+		const looksLikeTls =
+			data[0] === ContentTypes.Handshake &&
+			data[1] === 0x03 &&
+			data[2] >= 0x01 &&
+			data[2] <= 0x03;
+		if (looksLikeTls) {
+			return 'smtp-tls';
+		}
+	}
+
 	// Assume TLS if we're on the usual HTTPS port and the
 	// first three bytes look like a TLS handshake record.
 	const looksLikeTls =
@@ -413,6 +521,20 @@ function guessProtocol(port: number, data: Uint8Array) {
 		data[2] <= 0x03;
 	if (looksLikeTls) {
 		return 'tls';
+	}
+
+	// Check for plaintext SMTP on standard SMTP ports (25, 587)
+	// SMTP clients typically start with EHLO or HELO
+	if (isSMTPPort(port) && port !== 465) {
+		const decodedFirstLine = new TextDecoder('latin1', {
+			fatal: true,
+		}).decode(data);
+		const upperLine = decodedFirstLine.toUpperCase();
+		const looksLikeSMTP =
+			upperLine.startsWith('EHLO ') || upperLine.startsWith('HELO ');
+		if (looksLikeSMTP) {
+			return 'smtp';
+		}
 	}
 
 	// Assume HTTP if we're on the usual HTTP port and the


### PR DESCRIPTION
Implement SMTP interception similar to existing TLS handling:
- Create MockSMTPServer class that handles SMTP protocol
- Support EHLO/HELO, AUTH, MAIL FROM, RCPT TO, DATA, QUIT commands
- Store captured emails in exported capturedEmails array
- Handle both plaintext SMTP (ports 25, 587) and SMTPS (port 465)
- Export capturedEmails and clearCapturedEmails from php-wasm-web

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a mock SMTP server and wire it into TCPOverFetchWebsocket to intercept SMTP/SMTPS traffic and store captured emails, with new SMTP utilities exported.
> 
> - **Networking (tcp-over-fetch-websocket)**:
>   - Add SMTP handling (`handleSMTP`) and SMTPS handling over TLS (`handleSMTPOverTLS`).
>   - Extend protocol detection to recognize SMTP on ports `25/587` and SMTPS on port `465`.
>   - Pipe client streams to/from the mock SMTP server (and through TLS for SMTPS).
> - **New SMTP module (`lib/smtp/`)**:
>   - Implement `MockSMTPServer` handling `EHLO/HELO`, `AUTH`, `MAIL FROM`, `RCPT TO`, `DATA`, `QUIT`, `RSET`, `NOOP`, `STARTTLS` responses.
>   - Store emails in `capturedEmails`; utilities: `clearCapturedEmails`, `isSMTPPort`, `SMTP_PORTS`; type `CapturedEmail`.
> - **Exports**:
>   - Re-export SMTP utilities via `lib/index.ts` and `lib/smtp/index.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79c2a173559cb06686cff0ad5fa1c5def4cb2a86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->