### PR TITLE
[Website] Add Git Repository Import modal for creating Playgrounds from arbitrary git repos

### DIFF
--- a/packages/playground/website/src/components/git-repo-import-modal/form.tsx
+++ b/packages/playground/website/src/components/git-repo-import-modal/form.tsx
@@ -1,0 +1,509 @@
+import React, { useState, useCallback, useMemo } from 'react';
+import { Button as WPButton } from '@wordpress/components';
+import { Icon, chevronDown, chevronRight } from '@wordpress/icons';
+import {
+	listGitRefs,
+	listGitFiles,
+	resolveCommitHash,
+	GitAuthenticationError,
+} from '@wp-playground/storage';
+import type { GitFileTree } from '@wp-playground/storage';
+import { Spinner } from '../spinner';
+import Button from '../button';
+import css from './style.module.css';
+
+export interface GitRepoImportFormProps {
+	onSubmit: (config: {
+		repoUrl: string;
+		ref: string;
+		refType: 'branch' | 'tag';
+		sourcePath: string;
+		targetPath: string;
+	}) => void;
+	onClose: () => void;
+}
+
+interface LoadingState {
+	refs: boolean;
+	files: boolean;
+}
+
+interface GitRefInfo {
+	name: string;
+	oid: string;
+	type: 'branch' | 'tag';
+}
+
+export default function GitRepoImportForm({
+	onSubmit,
+	onClose,
+}: GitRepoImportFormProps) {
+	const [repoUrl, setRepoUrl] = useState('');
+	const [errors, setErrors] = useState<Record<string, string>>({});
+	const [loading, setLoading] = useState<LoadingState>({
+		refs: false,
+		files: false,
+	});
+
+	// Repository metadata
+	const [refs, setRefs] = useState<GitRefInfo[]>([]);
+	const [selectedRef, setSelectedRef] = useState<GitRefInfo | null>(null);
+	const [fileTree, setFileTree] = useState<GitFileTree[] | null>(null);
+
+	// User selections
+	const [sourcePath, setSourcePath] = useState('/');
+	const [targetPath, setTargetPath] = useState('/wordpress/wp-content');
+
+	// UI state
+	const [expandedFolders, setExpandedFolders] = useState<Set<string>>(
+		new Set(['/'])
+	);
+	const [repoLoaded, setRepoLoaded] = useState(false);
+
+	const normalizeGitUrl = (url: string): string => {
+		let normalized = url.trim();
+		// Remove trailing slashes
+		normalized = normalized.replace(/\/+$/, '');
+		// Add .git suffix if not present and it's a GitHub/GitLab URL
+		if (
+			!normalized.endsWith('.git') &&
+			(normalized.includes('github.com') ||
+				normalized.includes('gitlab.com'))
+		) {
+			normalized = normalized + '.git';
+		}
+		// Convert SSH URLs to HTTPS
+		if (normalized.startsWith('git@')) {
+			normalized = normalized
+				.replace('git@', 'https://')
+				.replace(':', '/');
+		}
+		return normalized;
+	};
+
+	const handleLoadRepository = async () => {
+		setErrors({});
+		const normalizedUrl = normalizeGitUrl(repoUrl);
+		if (!normalizedUrl) {
+			setErrors({ url: 'Please enter a repository URL' });
+			return;
+		}
+
+		setLoading({ refs: true, files: false });
+		setRefs([]);
+		setSelectedRef(null);
+		setFileTree(null);
+		setRepoLoaded(false);
+
+		try {
+			// Fetch branches
+			const branchRefs = await listGitRefs(normalizedUrl, 'refs/heads/');
+			const tagRefs = await listGitRefs(normalizedUrl, 'refs/tags/');
+
+			const allRefs: GitRefInfo[] = [];
+
+			// Process branches
+			for (const [refPath, oid] of Object.entries(branchRefs)) {
+				const name = refPath.replace('refs/heads/', '');
+				allRefs.push({ name, oid, type: 'branch' });
+			}
+
+			// Process tags
+			for (const [refPath, oid] of Object.entries(tagRefs)) {
+				const name = refPath.replace('refs/tags/', '');
+				allRefs.push({ name, oid, type: 'tag' });
+			}
+
+			if (allRefs.length === 0) {
+				setErrors({
+					url: 'No branches or tags found. Make sure the repository is public and the URL is correct.',
+				});
+				return;
+			}
+
+			// Sort: branches first (with main/master at top), then tags
+			allRefs.sort((a, b) => {
+				if (a.type !== b.type) {
+					return a.type === 'branch' ? -1 : 1;
+				}
+				// Prioritize main/master
+				if (a.name === 'main' || a.name === 'master') return -1;
+				if (b.name === 'main' || b.name === 'master') return 1;
+				return a.name.localeCompare(b.name);
+			});
+
+			setRefs(allRefs);
+			setRepoUrl(normalizedUrl);
+			setRepoLoaded(true);
+
+			// Auto-select first ref (usually main/master)
+			if (allRefs.length > 0) {
+				await handleSelectRef(allRefs[0], normalizedUrl);
+			}
+		} catch (error) {
+			if (error instanceof GitAuthenticationError) {
+				setErrors({
+					url: 'This repository requires authentication. Please use a public repository.',
+				});
+			} else {
+				setErrors({
+					url: `Failed to load repository: ${(error as Error).message}`,
+				});
+			}
+		} finally {
+			setLoading((prev) => ({ ...prev, refs: false }));
+		}
+	};
+
+	const handleSelectRef = async (ref: GitRefInfo, url?: string) => {
+		setSelectedRef(ref);
+		setFileTree(null);
+		setLoading((prev) => ({ ...prev, files: true }));
+		setErrors({});
+		setSourcePath('/');
+		setExpandedFolders(new Set(['/']));
+
+		const repoToUse = url || repoUrl;
+
+		try {
+			const commitHash = await resolveCommitHash(repoToUse, {
+				value: ref.name,
+				type: ref.type,
+			});
+
+			const files = await listGitFiles(repoToUse, commitHash);
+			setFileTree(files);
+		} catch (error) {
+			setErrors({
+				files: `Failed to load files: ${(error as Error).message}`,
+			});
+		} finally {
+			setLoading((prev) => ({ ...prev, files: false }));
+		}
+	};
+
+	const handleRefChange = async (
+		event: React.ChangeEvent<HTMLSelectElement>
+	) => {
+		const refName = event.target.value;
+		const ref = refs.find((r) => `${r.type}:${r.name}` === refName);
+		if (ref) {
+			await handleSelectRef(ref);
+		}
+	};
+
+	const toggleFolder = useCallback((path: string) => {
+		setExpandedFolders((prev) => {
+			const next = new Set(prev);
+			if (next.has(path)) {
+				next.delete(path);
+			} else {
+				next.add(path);
+			}
+			return next;
+		});
+	}, []);
+
+	const handleSelectPath = useCallback((path: string) => {
+		setSourcePath(path);
+	}, []);
+
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		if (!selectedRef) {
+			setErrors({ ref: 'Please select a branch or tag' });
+			return;
+		}
+		if (!sourcePath) {
+			setErrors({ sourcePath: 'Please select a source path' });
+			return;
+		}
+		if (!targetPath.trim()) {
+			setErrors({ targetPath: 'Please enter a target path' });
+			return;
+		}
+
+		onSubmit({
+			repoUrl,
+			ref: selectedRef.name,
+			refType: selectedRef.type,
+			sourcePath: sourcePath === '/' ? '' : sourcePath,
+			targetPath: targetPath.trim(),
+		});
+	};
+
+	const isLoading = loading.refs || loading.files;
+	const canSubmit = repoLoaded && selectedRef && !isLoading;
+
+	return (
+		<form onSubmit={handleSubmit} className={css.formContainer}>
+			<div className={css.formSection}>
+				<label className={css.formLabel}>Git Repository URL</label>
+				<div style={{ display: 'flex', gap: 8 }}>
+					<input
+						type="text"
+						value={repoUrl}
+						className={css.repoInput}
+						onChange={(e) => {
+							setRepoUrl(e.target.value);
+							setRepoLoaded(false);
+							setRefs([]);
+							setFileTree(null);
+						}}
+						placeholder="https://github.com/owner/repo.git"
+						autoFocus
+						disabled={loading.refs}
+					/>
+					<WPButton
+						variant="secondary"
+						onClick={handleLoadRepository}
+						disabled={!repoUrl.trim() || loading.refs}
+					>
+						{loading.refs ? 'Loading...' : 'Load'}
+					</WPButton>
+				</div>
+				{errors.url && (
+					<div className={css.errorMessage}>{errors.url}</div>
+				)}
+				<p className={css.formHint}>
+					Enter the URL of a public Git repository (GitHub, GitLab,
+					etc.)
+				</p>
+			</div>
+
+			{repoLoaded && (
+				<>
+					<div className={css.formSection}>
+						<label className={css.formLabel}>Branch or Tag</label>
+						<select
+							className={css.branchSelect}
+							value={
+								selectedRef
+									? `${selectedRef.type}:${selectedRef.name}`
+									: ''
+							}
+							onChange={handleRefChange}
+							disabled={loading.files}
+						>
+							<option value="">-- Select a ref --</option>
+							{refs.some((r) => r.type === 'branch') && (
+								<optgroup label="Branches">
+									{refs
+										.filter((r) => r.type === 'branch')
+										.map((ref) => (
+											<option
+												key={`branch:${ref.name}`}
+												value={`branch:${ref.name}`}
+											>
+												{ref.name}
+											</option>
+										))}
+								</optgroup>
+							)}
+							{refs.some((r) => r.type === 'tag') && (
+								<optgroup label="Tags">
+									{refs
+										.filter((r) => r.type === 'tag')
+										.map((ref) => (
+											<option
+												key={`tag:${ref.name}`}
+												value={`tag:${ref.name}`}
+											>
+												{ref.name}
+											</option>
+										))}
+								</optgroup>
+							)}
+						</select>
+						{errors.ref && (
+							<div className={css.errorMessage}>{errors.ref}</div>
+						)}
+					</div>
+
+					{loading.files && (
+						<div className={css.loadingContainer}>
+							<Spinner size={30} />
+							<span className={css.loadingText}>
+								Loading repository files...
+							</span>
+						</div>
+					)}
+
+					{fileTree && !loading.files && (
+						<div className={css.formSection}>
+							<label className={css.formLabel}>
+								Source Path in Repository
+							</label>
+							<p className={css.formHint}>
+								Select a folder or the root to import
+							</p>
+							<div className={css.fileTreeContainer}>
+								<GitFileTreeView
+									files={fileTree}
+									selectedPath={sourcePath}
+									expandedFolders={expandedFolders}
+									onToggleFolder={toggleFolder}
+									onSelectPath={handleSelectPath}
+									parentPath=""
+								/>
+							</div>
+							<div className={css.selectedPathDisplay}>
+								Selected: {sourcePath || '/'}
+							</div>
+							{errors.sourcePath && (
+								<div className={css.errorMessage}>
+									{errors.sourcePath}
+								</div>
+							)}
+						</div>
+					)}
+
+					{fileTree && !loading.files && (
+						<div className={css.formSection}>
+							<label className={css.formLabel}>
+								Target Path in Playground
+							</label>
+							<input
+								type="text"
+								value={targetPath}
+								className={css.pathInput}
+								onChange={(e) => setTargetPath(e.target.value)}
+								placeholder="/wordpress/wp-content/plugins/my-plugin"
+							/>
+							<p className={css.formHint}>
+								Where to write the files in your Playground
+								(e.g., /wordpress/wp-content/plugins/my-plugin)
+							</p>
+							{errors.targetPath && (
+								<div className={css.errorMessage}>
+									{errors.targetPath}
+								</div>
+							)}
+						</div>
+					)}
+				</>
+			)}
+
+			<div className={css.submitRow}>
+				<WPButton variant="tertiary" onClick={onClose}>
+					Cancel
+				</WPButton>
+				<Button
+					type="submit"
+					variant="primary"
+					size="large"
+					disabled={!canSubmit}
+				>
+					Create Playground
+				</Button>
+			</div>
+		</form>
+	);
+}
+
+interface GitFileTreeViewProps {
+	files: GitFileTree[];
+	selectedPath: string;
+	expandedFolders: Set<string>;
+	onToggleFolder: (path: string) => void;
+	onSelectPath: (path: string) => void;
+	parentPath: string;
+}
+
+function GitFileTreeView({
+	files,
+	selectedPath,
+	expandedFolders,
+	onToggleFolder,
+	onSelectPath,
+	parentPath,
+}: GitFileTreeViewProps) {
+	// Sort: folders first, then files, alphabetically
+	const sortedFiles = useMemo(() => {
+		return [...files].sort((a, b) => {
+			if (a.type !== b.type) {
+				return a.type === 'folder' ? -1 : 1;
+			}
+			return a.name.localeCompare(b.name);
+		});
+	}, [files]);
+
+	// Show root selector first if we're at the top level
+	const isTopLevel = parentPath === '';
+
+	return (
+		<div>
+			{isTopLevel && (
+				<div
+					className={`${css.treeNode} ${selectedPath === '/' ? css.treeNodeSelected : ''}`}
+					onClick={() => onSelectPath('/')}
+				>
+					<span className={css.treeTogglePlaceholder} />
+					<span className={css.treeNodeIcon}>📁</span>
+					<span>/ (repository root)</span>
+				</div>
+			)}
+			{sortedFiles.map((file) => {
+				const fullPath = parentPath
+					? `${parentPath}/${file.name}`
+					: `/${file.name}`;
+				const isFolder = file.type === 'folder';
+				const isExpanded = expandedFolders.has(fullPath);
+				const isSelected = selectedPath === fullPath;
+
+				return (
+					<div key={fullPath}>
+						<div
+							className={`${css.treeNode} ${isSelected ? css.treeNodeSelected : ''}`}
+							onClick={() => {
+								if (isFolder) {
+									onSelectPath(fullPath);
+								}
+							}}
+						>
+							{isFolder ? (
+								<span
+									className={css.treeToggle}
+									onClick={(e) => {
+										e.stopPropagation();
+										onToggleFolder(fullPath);
+									}}
+								>
+									<Icon
+										icon={
+											isExpanded
+												? chevronDown
+												: chevronRight
+										}
+										size={16}
+									/>
+								</span>
+							) : (
+								<span className={css.treeTogglePlaceholder} />
+							)}
+							<span className={css.treeNodeIcon}>
+								{isFolder ? '📁' : '📄'}
+							</span>
+							<span>{file.name}</span>
+						</div>
+						{isFolder &&
+							isExpanded &&
+							file.type === 'folder' &&
+							file.children && (
+								<div className={css.treeNodeChildren}>
+									<GitFileTreeView
+										files={file.children}
+										selectedPath={selectedPath}
+										expandedFolders={expandedFolders}
+										onToggleFolder={onToggleFolder}
+										onSelectPath={onSelectPath}
+										parentPath={fullPath}
+									/>
+								</div>
+							)}
+					</div>
+				);
+			})}
+		</div>
+	);
+}

--- a/packages/playground/website/src/components/git-repo-import-modal/index.tsx
+++ b/packages/playground/website/src/components/git-repo-import-modal/index.tsx
@@ -1,0 +1,76 @@
+import { useDispatch } from 'react-redux';
+import {
+	setActiveModal,
+	setSiteManagerOpen,
+} from '../../lib/state/redux/slice-ui';
+import type { PlaygroundDispatch } from '../../lib/state/redux/store';
+import { Modal } from '../modal';
+import GitRepoImportForm from './form';
+import { PlaygroundRoute, redirectTo } from '../../lib/state/url/router';
+
+export function GitRepoImportModal() {
+	const dispatch: PlaygroundDispatch = useDispatch();
+
+	const closeModal = () => {
+		dispatch(setActiveModal(null));
+	};
+
+	const handleSubmit = (config: {
+		repoUrl: string;
+		ref: string;
+		refType: 'branch' | 'tag';
+		sourcePath: string;
+		targetPath: string;
+	}) => {
+		// Create a Blueprint with a writeFiles step using a git:directory resource
+		const blueprint = {
+			landingPage: '/wp-admin/',
+			steps: [
+				{
+					step: 'writeFiles',
+					writeToPath: config.targetPath,
+					filesTree: {
+						resource: 'git:directory',
+						url: config.repoUrl,
+						ref: config.ref,
+						refType: config.refType,
+						path: config.sourcePath || undefined,
+					},
+				},
+			],
+		};
+
+		// Encode the blueprint as base64 for the URL
+		const blueprintJson = JSON.stringify(blueprint);
+		const blueprintBase64 = btoa(
+			encodeURIComponent(blueprintJson).replace(
+				/%([0-9A-F]{2})/g,
+				(_, p1) => String.fromCharCode(parseInt(p1, 16))
+			)
+		);
+
+		dispatch(setSiteManagerOpen(false));
+		closeModal();
+
+		// Redirect to a new temporary site with the blueprint
+		redirectTo(
+			PlaygroundRoute.newTemporarySite({
+				query: {
+					blueprint: blueprintBase64,
+				},
+			})
+		);
+	};
+
+	return (
+		<Modal
+			title="Import from Git Repository"
+			onRequestClose={closeModal}
+			contentLabel='This is a dialog window which overlays the main content of the page. The modal begins with a heading 2 called "Import from Git Repository". Pressing the Close button will close the modal and bring you back to where you were on the page.'
+		>
+			<GitRepoImportForm onSubmit={handleSubmit} onClose={closeModal} />
+		</Modal>
+	);
+}
+
+export { GitRepoImportForm };

--- a/packages/playground/website/src/components/git-repo-import-modal/style.module.css
+++ b/packages/playground/website/src/components/git-repo-import-modal/style.module.css
@@ -1,0 +1,157 @@
+.formContainer {
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+}
+
+.loadingContainer {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	padding: 40px 20px;
+	gap: 16px;
+}
+
+.loadingText {
+	color: #666;
+	font-size: 14px;
+}
+
+.branchSelect {
+	width: 100%;
+	padding: 8px 12px;
+	font-size: 14px;
+	border: 1px solid #ccc;
+	border-radius: 4px;
+	background: white;
+}
+
+.fileTreeContainer {
+	border: 1px solid #ddd;
+	border-radius: 4px;
+	max-height: 250px;
+	overflow-y: auto;
+	padding: 8px;
+	background: #fafafa;
+}
+
+.pathInput {
+	width: 100%;
+	padding: 8px 12px;
+	font-size: 14px;
+	border: 1px solid #ccc;
+	border-radius: 4px;
+}
+
+.selectedPathDisplay {
+	margin-top: 8px;
+	padding: 8px 12px;
+	background: #f0f0f0;
+	border-radius: 4px;
+	font-family: monospace;
+	font-size: 13px;
+	color: #333;
+}
+
+.errorMessage {
+	color: #d63638;
+	font-size: 13px;
+	margin-top: 4px;
+}
+
+.formSection {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.formLabel {
+	font-weight: 500;
+	font-size: 14px;
+	color: #1e1e1e;
+}
+
+.formHint {
+	font-size: 12px;
+	color: #757575;
+	margin-top: 4px;
+}
+
+.submitRow {
+	display: flex;
+	flex-direction: row;
+	justify-content: flex-end;
+	align-items: center;
+	gap: 12px;
+	margin-top: 8px;
+	padding-top: 16px;
+	border-top: 1px solid #eaeaea;
+}
+
+.repoInput {
+	width: 100%;
+	padding: 8px 12px;
+	font-size: 14px;
+	border: 1px solid #ccc;
+	border-radius: 4px;
+}
+
+.repoInput:focus {
+	border-color: #007cba;
+	outline: none;
+	box-shadow: 0 0 0 1px #007cba;
+}
+
+.notice {
+	background: #f0f6fc;
+	border-left: 4px solid #007cba;
+	padding: 12px;
+	margin: 0;
+	font-size: 13px;
+}
+
+.treeNode {
+	display: flex;
+	align-items: center;
+	padding: 4px 8px;
+	cursor: pointer;
+	user-select: none;
+	border-radius: 4px;
+}
+
+.treeNode:hover {
+	background: #e9e9e9;
+}
+
+.treeNodeSelected {
+	background: #dbeafe;
+}
+
+.treeNodeSelected:hover {
+	background: #bfdbfe;
+}
+
+.treeNodeIcon {
+	margin-right: 6px;
+	color: #666;
+}
+
+.treeNodeChildren {
+	padding-left: 20px;
+}
+
+.treeToggle {
+	width: 16px;
+	height: 16px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	margin-right: 4px;
+	cursor: pointer;
+}
+
+.treeTogglePlaceholder {
+	width: 16px;
+	margin-right: 4px;
+}

--- a/packages/playground/website/src/components/layout/index.tsx
+++ b/packages/playground/website/src/components/layout/index.tsx
@@ -51,6 +51,12 @@ const PreviewPRModal = lazy(() =>
 	}))
 );
 
+const GitRepoImportModal = lazy(() =>
+	import('../git-repo-import-modal').then((m) => ({
+		default: m.GitRepoImportModal,
+	}))
+);
+
 const displayMode = getDisplayModeFromQuery();
 function getDisplayModeFromQuery(): DisplayMode {
 	const query = new URLSearchParams(document.location.search);
@@ -174,6 +180,12 @@ function Modals() {
 		return <GitHubPrivateRepoAuthModal />;
 	} else if (currentModal === modalSlugs.BLUEPRINT_URL) {
 		return <BlueprintUrlModal />;
+	} else if (currentModal === modalSlugs.GIT_REPO_IMPORT) {
+		return (
+			<LazyModal>
+				<GitRepoImportModal />
+			</LazyModal>
+		);
 	}
 
 	if (currentModal === modalSlugs.PREVIEW_PR_WP) {

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
@@ -69,6 +69,28 @@ function PullRequestIcon() {
 	);
 }
 
+// Git branch icon from Feather Icons
+function GitBranchIcon() {
+	return (
+		<svg
+			width="16"
+			height="16"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		>
+			<line x1="6" y1="3" x2="6" y2="15"></line>
+			<circle cx="18" cy="6" r="3"></circle>
+			<circle cx="6" cy="18" r="3"></circle>
+			<path d="M18 9a9 9 0 0 1-9 9"></path>
+		</svg>
+	);
+}
+
+// 3x3 grid icon from Bootstrap Icons (grid-3x3-gap-fill)
 function GridIcon({ size = 20 }: { size?: number }) {
 	return (
 		<svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor">
@@ -317,6 +339,15 @@ export function SavedPlaygroundsOverlay({
 					switchToTemporarySite();
 				}
 				modalDispatch(setActiveModal(modalSlugs.GITHUB_IMPORT));
+			},
+			disabled: offline,
+		},
+		{
+			id: 'git-repo',
+			title: 'Git Repository',
+			iconComponent: <GitBranchIcon />,
+			onClick: () => {
+				modalDispatch(setActiveModal(modalSlugs.GIT_REPO_IMPORT));
 			},
 			disabled: offline,
 		},

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -33,6 +33,7 @@ export const modalSlugs = {
 	SAVE_SITE: 'save-site',
 	DELETE_SITE: 'delete-site',
 	BLUEPRINT_URL: 'blueprint-url',
+	GIT_REPO_IMPORT: 'git-repo-import',
 } as const;
 
 export type SerializedPlainErrorDetails = {


### PR DESCRIPTION
Adds a new "Git Repository" option in the Playground creation menu that lets users:
- Enter a public Git repository URL (GitHub, GitLab, etc.)
- Browse branches/tags and choose a source directory
- Choose the target Playground path
- Launch a temporary Playground using a `writeFiles` step backed by a `git:directory` resource

## Refresh Notes
- Rebased onto current fork `trunk` / upstream `trunk` (`dac72f5b4`).
- Resolved conflicts in the current layout modal router, saved-playgrounds creation menu, and UI modal slug state.
- Kept the current lazy modal/code-splitting pattern for the new Git repository import modal.
- Removed stale imports that caused the previous `Lint and typecheck` failure.

## Validation
- `git diff --check`
- `npx prettier --check packages/playground/website/src/components/git-repo-import-modal/form.tsx packages/playground/website/src/components/git-repo-import-modal/index.tsx packages/playground/website/src/components/git-repo-import-modal/style.module.css packages/playground/website/src/components/layout/index.tsx packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx packages/playground/website/src/lib/state/redux/slice-ui.ts`
- `npx nx run playground-website:lint --skip-nx-cache`
- `npx nx run playground-website:typecheck --skip-nx-cache`
- `npx nx run playground-website:build --skip-nx-cache`

## Notes
- The website build passes with existing project warnings from Vite/sourcemaps/eval/chunk-size/browser externalization.
- Current head: `13cb4af7a58e2fa65a547a3b4a93644001f29134`.