### PR TITLE
feat: add debug timeline for Playground developers

### DIFF
--- a/packages/php-wasm/logger/src/index.ts
+++ b/packages/php-wasm/logger/src/index.ts
@@ -1,3 +1,5 @@
 export * from './lib/logger';
 export * from './lib/log-collector';
 export * from './lib/log-handlers';
+export * from './lib/timeline';
+export * from './lib/collectors/collect-timeline-events';

--- a/packages/php-wasm/logger/src/lib/collectors/collect-timeline-events.ts
+++ b/packages/php-wasm/logger/src/lib/collectors/collect-timeline-events.ts
@@ -1,0 +1,233 @@
+import type { DebugTimeline } from '../timeline/debug-timeline';
+
+/**
+ * Interface for PHP event sources (UniversalPHP or PlaygroundClient).
+ */
+interface PHPEventSource {
+	addEventListener(event: string, listener: (event: unknown) => void): void;
+}
+
+/**
+ * Interface for request error events.
+ */
+interface RequestErrorEvent {
+	error?: Error;
+	source?: 'request' | 'php-wasm';
+}
+
+/**
+ * Collect PHP runtime events and log them to the timeline.
+ */
+export function collectPhpRuntimeEvents(
+	timeline: DebugTimeline,
+	php: PHPEventSource
+): void {
+	php.addEventListener('runtime.initialized', () => {
+		timeline.log({
+			category: 'runtime',
+			type: 'runtime.initialized',
+			message: 'PHP runtime initialized',
+		});
+	});
+
+	php.addEventListener('runtime.beforeExit', () => {
+		timeline.log({
+			category: 'runtime',
+			type: 'runtime.beforeExit',
+			message: 'PHP runtime exiting',
+		});
+	});
+
+	php.addEventListener('request.end', () => {
+		timeline.log({
+			category: 'php',
+			type: 'php.request.end',
+			message: 'PHP request completed',
+		});
+	});
+
+	php.addEventListener('request.error', (event: unknown) => {
+		const errorEvent = event as RequestErrorEvent;
+		timeline.log({
+			category: 'php',
+			type: 'php.request.error',
+			message: `PHP request error: ${errorEvent.error?.message || 'Unknown error'}`,
+			data: {
+				source: errorEvent.source,
+				errorMessage: errorEvent.error?.message,
+				errorStack: errorEvent.error?.stack,
+			},
+		});
+	});
+
+	// Filesystem events are verbose-only
+	php.addEventListener('filesystem.write', () => {
+		timeline.log({
+			category: 'filesystem',
+			type: 'filesystem.write',
+			message: 'Filesystem write operation',
+			verbose: true,
+		});
+	});
+}
+
+/**
+ * Options for blueprint step callbacks.
+ */
+export interface BlueprintStepCallbacks {
+	/** Original callback to call after logging */
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	onStepCompleted?: (output: any, step: any) => any;
+}
+
+/**
+ * Create blueprint V1 step callbacks that log to the timeline.
+ * The callback signature matches `OnStepCompleted = (output: any, step: StepDefinition) => any`
+ */
+export function createBlueprintV1Callbacks(
+	timeline: DebugTimeline,
+	options: BlueprintStepCallbacks = {}
+): {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	onStepCompleted: (output: any, step: any) => any;
+} {
+	let stepIndex = 0;
+	return {
+		onStepCompleted: (output: unknown, step: unknown) => {
+			const stepObj = step as {
+				step?: string;
+				progress?: { caption?: string };
+			};
+			const stepName = stepObj.step || 'unknown';
+			const caption = stepObj.progress?.caption;
+
+			timeline.log({
+				category: 'blueprint',
+				type: 'blueprint.step.finish',
+				message: caption
+					? `Blueprint step ${stepIndex + 1} completed: ${stepName} - ${caption}`
+					: `Blueprint step ${stepIndex + 1} completed: ${stepName}`,
+				data: { stepIndex, stepName },
+			});
+
+			stepIndex++;
+
+			// Call original handler if provided
+			return options.onStepCompleted?.(output, step);
+		},
+	};
+}
+
+/**
+ * Blueprint V2 message types.
+ */
+interface BlueprintMessage {
+	type: string;
+	progress?: number;
+	caption?: string;
+	message?: string;
+	details?: unknown;
+}
+
+/**
+ * Interface for Playground client with blueprint message events.
+ */
+interface PlaygroundWithEvents {
+	addEventListener(
+		event: 'blueprint.message',
+		listener: (event: { message: BlueprintMessage }) => void
+	): void;
+	onNavigation?(callback: (path: string) => void): void;
+}
+
+/**
+ * Collect Blueprint V2 message events and log them to the timeline.
+ */
+export function collectBlueprintV2Events(
+	timeline: DebugTimeline,
+	playground: PlaygroundWithEvents
+): void {
+	playground.addEventListener('blueprint.message', ({ message }) => {
+		switch (message.type) {
+			case 'blueprint.progress':
+				timeline.log({
+					category: 'blueprint',
+					type: 'blueprint.progress',
+					message: message.caption || 'Blueprint progress',
+					data: { progress: message.progress },
+				});
+				break;
+
+			case 'blueprint.error':
+				timeline.log({
+					category: 'blueprint',
+					type: 'blueprint.step.error',
+					message: `Blueprint error: ${message.message || 'Unknown error'}`,
+					data: { details: message.details },
+				});
+				break;
+
+			case 'blueprint.completion':
+				timeline.log({
+					category: 'blueprint',
+					type: 'blueprint.step.finish',
+					message: message.message || 'Blueprint completed',
+				});
+				break;
+		}
+	});
+}
+
+/**
+ * Collect navigation events and log them to the timeline.
+ */
+export function collectNavigationEvents(
+	timeline: DebugTimeline,
+	playground: PlaygroundWithEvents
+): void {
+	if (!playground.onNavigation) {
+		return;
+	}
+
+	playground.onNavigation((path: string) => {
+		timeline.log({
+			category: 'navigation',
+			type: 'navigation.request',
+			message: `Navigation to: ${path}`,
+			data: { path },
+		});
+	});
+}
+
+/**
+ * Log a query parameter change event.
+ */
+export function logQueryParamsChange(
+	timeline: DebugTimeline,
+	oldParams: string,
+	newParams: string
+): void {
+	timeline.log({
+		category: 'navigation',
+		type: 'query.params.change',
+		message: `Query params changed: ${oldParams} -> ${newParams}`,
+		data: { oldParams, newParams },
+	});
+}
+
+/**
+ * Log an external API call (for tracking calls from integrators).
+ */
+export function logExternalCall(
+	timeline: DebugTimeline,
+	method: string,
+	args?: unknown
+): void {
+	timeline.log({
+		category: 'external',
+		type: 'external.request',
+		message: `External API call: ${method}`,
+		data: { method, args },
+		caller: { type: 'external' },
+	});
+}

--- a/packages/php-wasm/logger/src/lib/timeline/debug-timeline.ts
+++ b/packages/php-wasm/logger/src/lib/timeline/debug-timeline.ts
@@ -1,0 +1,300 @@
+import type { TimelineEntry, TimelineEntryInput } from './timeline-entry';
+import type { TimelineSession } from './timeline-session';
+import { logger } from '../logger';
+import { TimelineStorage } from './timeline-storage';
+
+/**
+ * Options for initializing the debug timeline.
+ */
+export interface DebugTimelineOptions {
+	/** Enable verbose mode to capture additional events */
+	verboseMode: boolean;
+	/** Associated site slug */
+	siteSlug?: string;
+	/** PHP version for this session */
+	phpVersion?: string;
+	/** WordPress version for this session */
+	wpVersion?: string;
+}
+
+/**
+ * Export formats for timeline sessions.
+ */
+export type TimelineExportFormat = 'jsonl' | 'json' | 'csv';
+
+/**
+ * Debug timeline for tracking Playground events with OPFS persistence.
+ *
+ * Usage:
+ * ```ts
+ * const timeline = new DebugTimeline({ verboseMode: true });
+ * await timeline.initialize();
+ *
+ * timeline.log({
+ *   category: 'blueprint',
+ *   type: 'blueprint.step.finish',
+ *   message: 'Step completed: installPlugin',
+ * });
+ *
+ * const sessions = await timeline.listSessions();
+ * ```
+ */
+export class DebugTimeline {
+	private storage: TimelineStorage | null = null;
+	private currentSession: TimelineSession | null = null;
+	private sessionStartTime = 0;
+	private options: DebugTimelineOptions;
+	private buffer: TimelineEntry[] = [];
+	private flushScheduled = false;
+	private flushPromise: Promise<void> | null = null;
+
+	constructor(options: DebugTimelineOptions) {
+		this.options = options;
+	}
+
+	/**
+	 * Initialize the timeline storage and create a new session.
+	 * Must be called before logging entries.
+	 */
+	async initialize(): Promise<void> {
+		if (!TimelineStorage.isAvailable()) {
+			logger.warn(
+				'Debug Timeline: OPFS not available, timeline will be in-memory only'
+			);
+			return;
+		}
+
+		try {
+			this.storage = await TimelineStorage.create();
+		} catch (error) {
+			logger.warn('Debug Timeline: Failed to initialize storage', error);
+			return;
+		}
+
+		this.sessionStartTime = performance.now();
+
+		this.currentSession = {
+			id: this.generateUUID(),
+			startTime: new Date().toISOString(),
+			entryCount: 0,
+			siteSlug: this.options.siteSlug,
+			phpVersion: this.options.phpVersion,
+			wpVersion: this.options.wpVersion,
+			userAgent:
+				typeof navigator !== 'undefined'
+					? navigator.userAgent
+					: 'unknown',
+			verboseMode: this.options.verboseMode,
+		};
+
+		await this.storage.createSession(this.currentSession);
+	}
+
+	/**
+	 * Log a timeline entry.
+	 */
+	log(entry: TimelineEntryInput): void {
+		if (!this.currentSession) return;
+
+		// Skip verbose entries if not in verbose mode
+		if (entry.verbose && !this.options.verboseMode) return;
+
+		const fullEntry: TimelineEntry = {
+			...entry,
+			timestamp: this.formatTimestamp(new Date()),
+			relativeMs:
+				Math.round((performance.now() - this.sessionStartTime) * 100) /
+				100,
+		};
+
+		this.buffer.push(fullEntry);
+		this.scheduleFlush();
+	}
+
+	/**
+	 * End the current session.
+	 */
+	async endSession(): Promise<void> {
+		if (!this.currentSession || !this.storage) return;
+
+		// Wait for any pending flush
+		if (this.flushPromise) {
+			await this.flushPromise;
+		}
+
+		// Flush remaining entries
+		await this.flushBuffer();
+
+		await this.storage.updateSession(this.currentSession.id, {
+			endTime: new Date().toISOString(),
+			entryCount: this.currentSession.entryCount,
+		});
+	}
+
+	/**
+	 * Get all available sessions.
+	 */
+	async listSessions(): Promise<TimelineSession[]> {
+		if (!this.storage) return [];
+		return this.storage.listSessions();
+	}
+
+	/**
+	 * Read all entries from a session.
+	 */
+	async readSession(id: string): Promise<TimelineEntry[]> {
+		if (!this.storage) return [];
+		return this.storage.readSession(id);
+	}
+
+	/**
+	 * Read the latest n entries from the current session.
+	 */
+	async readLatest(n = 10): Promise<TimelineEntry[]> {
+		if (!this.currentSession) return [];
+
+		// Include buffered entries that haven't been flushed yet
+		let entries: TimelineEntry[] = [];
+		if (this.storage) {
+			entries = await this.storage.readSession(this.currentSession.id);
+		}
+
+		// Add buffer entries
+		entries = entries.concat(this.buffer);
+
+		return entries.slice(-n);
+	}
+
+	/**
+	 * Clear all sessions.
+	 */
+	async clearSessions(): Promise<void> {
+		if (!this.storage) return;
+		await this.storage.clearAllSessions();
+	}
+
+	/**
+	 * Export a session in the specified format.
+	 */
+	async exportSession(
+		id: string,
+		format: TimelineExportFormat = 'jsonl'
+	): Promise<string> {
+		const entries = await this.readSession(id);
+
+		switch (format) {
+			case 'json':
+				return JSON.stringify(entries, null, 2);
+			case 'csv':
+				return this.entriesToCsv(entries);
+			case 'jsonl':
+			default:
+				return entries.map((e) => JSON.stringify(e)).join('\n');
+		}
+	}
+
+	/**
+	 * Get the current session info.
+	 */
+	getCurrentSession(): TimelineSession | null {
+		return this.currentSession;
+	}
+
+	/**
+	 * Check if the timeline is initialized and ready.
+	 */
+	isReady(): boolean {
+		return this.currentSession !== null;
+	}
+
+	// --- Private methods ---
+
+	private formatTimestamp(date: Date): string {
+		// Format: "2026-01-14T14:58:12.324150Z"
+		const iso = date.toISOString();
+		// Add microseconds precision from performance.now()
+		const microPart = String(
+			Math.floor((performance.now() % 1) * 1000)
+		).padStart(3, '0');
+		return iso.replace(/\.\d{3}Z$/, `.${iso.slice(20, 23)}${microPart}Z`);
+	}
+
+	private scheduleFlush(): void {
+		if (this.flushScheduled) return;
+		this.flushScheduled = true;
+
+		// Use requestIdleCallback for non-blocking writes
+		const doFlush = () => {
+			this.flushScheduled = false;
+			this.flushPromise = this.flushBuffer().finally(() => {
+				this.flushPromise = null;
+			});
+		};
+
+		if (typeof requestIdleCallback !== 'undefined') {
+			requestIdleCallback(doFlush, { timeout: 500 });
+		} else {
+			setTimeout(doFlush, 100);
+		}
+	}
+
+	private async flushBuffer(): Promise<void> {
+		if (this.buffer.length === 0 || !this.storage || !this.currentSession) {
+			return;
+		}
+
+		const entries = this.buffer.splice(0);
+
+		try {
+			await this.storage.appendEntries(this.currentSession.id, entries);
+			this.currentSession.entryCount += entries.length;
+
+			// Update session metadata periodically (every 10 entries)
+			if (this.currentSession.entryCount % 10 === 0) {
+				await this.storage.updateSession(this.currentSession.id, {
+					entryCount: this.currentSession.entryCount,
+				});
+			}
+		} catch (error) {
+			// Re-add entries to buffer on failure
+			this.buffer.unshift(...entries);
+			logger.warn('Debug Timeline: Failed to flush entries', error);
+		}
+	}
+
+	private entriesToCsv(entries: TimelineEntry[]): string {
+		const headers = [
+			'timestamp',
+			'relativeMs',
+			'category',
+			'type',
+			'message',
+			'data',
+		];
+		const escapeCell = (value: string) =>
+			`"${value.replace(/"/g, '""').replace(/\n/g, '\\n')}"`;
+
+		const rows = entries.map((e) => [
+			e.timestamp,
+			String(e.relativeMs),
+			e.category,
+			e.type,
+			escapeCell(e.message),
+			e.data ? escapeCell(JSON.stringify(e.data)) : '',
+		]);
+
+		return [headers.join(','), ...rows.map((r) => r.join(','))].join('\n');
+	}
+
+	private generateUUID(): string {
+		if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+			return crypto.randomUUID();
+		}
+		// Fallback for older browsers
+		return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+			const r = (Math.random() * 16) | 0;
+			const v = c === 'x' ? r : (r & 0x3) | 0x8;
+			return v.toString(16);
+		});
+	}
+}

--- a/packages/php-wasm/logger/src/lib/timeline/index.ts
+++ b/packages/php-wasm/logger/src/lib/timeline/index.ts
@@ -1,0 +1,4 @@
+export * from './timeline-entry';
+export * from './timeline-session';
+export * from './timeline-storage';
+export * from './debug-timeline';

--- a/packages/php-wasm/logger/src/lib/timeline/timeline-entry.ts
+++ b/packages/php-wasm/logger/src/lib/timeline/timeline-entry.ts
@@ -1,0 +1,79 @@
+/**
+ * Categories of timeline events for filtering and display.
+ */
+export type TimelineEventCategory =
+	| 'blueprint'
+	| 'php'
+	| 'navigation'
+	| 'runtime'
+	| 'filesystem'
+	| 'external';
+
+/**
+ * Specific types of timeline events.
+ */
+export type TimelineEventType =
+	// Blueprint events
+	| 'blueprint.step.start'
+	| 'blueprint.step.finish'
+	| 'blueprint.step.error'
+	| 'blueprint.progress'
+	| 'blueprint.validation'
+	// PHP events
+	| 'php.request.start'
+	| 'php.request.end'
+	| 'php.request.error'
+	| 'php.run.exit'
+	// Runtime events
+	| 'runtime.initialized'
+	| 'runtime.beforeExit'
+	| 'php.instance.spawn'
+	// Navigation events
+	| 'navigation.request'
+	| 'query.params.change'
+	// Filesystem events
+	| 'filesystem.write'
+	// External caller events
+	| 'external.writeFile'
+	| 'external.run'
+	| 'external.request';
+
+/**
+ * Information about what triggered the event.
+ */
+export interface TimelineEntryCaller {
+	/** Whether this was triggered internally or by an external API caller */
+	type: 'internal' | 'external';
+	/** Source description, e.g., "blueprint step 3", "user script" */
+	source?: string;
+}
+
+/**
+ * A single entry in the debug timeline.
+ */
+export interface TimelineEntry {
+	/** ISO 8601 timestamp with microseconds: "2026-01-14T14:58:12.324150Z" */
+	timestamp: string;
+	/** High-precision relative time in milliseconds from session start */
+	relativeMs: number;
+	/** Event category for filtering */
+	category: TimelineEventCategory;
+	/** Specific event type */
+	type: TimelineEventType;
+	/** Human-readable message */
+	message: string;
+	/** Optional structured data */
+	data?: Record<string, unknown>;
+	/** Optional caller information */
+	caller?: TimelineEntryCaller;
+	/** Verbose-only flag (only captured when verbose mode enabled) */
+	verbose?: boolean;
+}
+
+/**
+ * Input for creating a timeline entry (without auto-generated fields).
+ */
+export type TimelineEntryInput = Omit<
+	TimelineEntry,
+	'timestamp' | 'relativeMs'
+>;

--- a/packages/php-wasm/logger/src/lib/timeline/timeline-session.ts
+++ b/packages/php-wasm/logger/src/lib/timeline/timeline-session.ts
@@ -1,0 +1,33 @@
+/**
+ * Metadata for a debug timeline session.
+ */
+export interface TimelineSession {
+	/** Unique session identifier (UUID) */
+	id: string;
+	/** ISO 8601 timestamp when session started */
+	startTime: string;
+	/** ISO 8601 timestamp when session ended (set when session closes) */
+	endTime?: string;
+	/** Number of entries in this session */
+	entryCount: number;
+	/** Associated site slug if known */
+	siteSlug?: string;
+	/** PHP version used in this session */
+	phpVersion?: string;
+	/** WordPress version used in this session */
+	wpVersion?: string;
+	/** User agent string */
+	userAgent: string;
+	/** Whether verbose mode was enabled */
+	verboseMode: boolean;
+}
+
+/**
+ * Index file structure for tracking all sessions.
+ */
+export interface SessionsIndex {
+	/** Schema version for future compatibility */
+	version: 1;
+	/** List of sessions, ordered by most recent first */
+	sessions: TimelineSession[];
+}

--- a/packages/php-wasm/logger/src/lib/timeline/timeline-storage.ts
+++ b/packages/php-wasm/logger/src/lib/timeline/timeline-storage.ts
@@ -1,0 +1,244 @@
+import type { TimelineEntry } from './timeline-entry';
+import type { TimelineSession, SessionsIndex } from './timeline-session';
+
+const TIMELINE_ROOT = 'debug-timeline';
+const SESSIONS_INDEX = 'sessions.json';
+const MAX_SESSIONS = 10;
+
+/**
+ * Storage backend for debug timeline sessions using OPFS.
+ */
+export class TimelineStorage {
+	private opfsRoot: FileSystemDirectoryHandle;
+	private initialized = false;
+
+	private constructor(opfsRoot: FileSystemDirectoryHandle) {
+		this.opfsRoot = opfsRoot;
+	}
+
+	/**
+	 * Create a TimelineStorage instance.
+	 * @returns A fully initialized TimelineStorage
+	 * @throws Error if OPFS is not available
+	 */
+	static async create(): Promise<TimelineStorage> {
+		if (typeof navigator === 'undefined') {
+			throw new Error('OPFS not available: navigator is undefined');
+		}
+		if (!navigator.storage || !navigator.storage.getDirectory) {
+			throw new Error('OPFS not available: storage API not supported');
+		}
+
+		const root = await navigator.storage.getDirectory();
+		const timelineDir = await root.getDirectoryHandle(TIMELINE_ROOT, {
+			create: true,
+		});
+
+		const storage = new TimelineStorage(timelineDir);
+		await storage.initialize();
+		return storage;
+	}
+
+	/**
+	 * Check if OPFS is available in the current environment.
+	 */
+	static isAvailable(): boolean {
+		return (
+			typeof navigator !== 'undefined' &&
+			navigator.storage !== undefined &&
+			typeof navigator.storage.getDirectory === 'function'
+		);
+	}
+
+	private async initialize(): Promise<void> {
+		if (this.initialized) return;
+
+		// Ensure sessions.json exists
+		const exists = await this.fileExists(SESSIONS_INDEX);
+		if (!exists) {
+			const index: SessionsIndex = { version: 1, sessions: [] };
+			await this.writeJson(SESSIONS_INDEX, index);
+		}
+
+		this.initialized = true;
+	}
+
+	/**
+	 * Append a timeline entry to a session file.
+	 */
+	async appendEntry(sessionId: string, entry: TimelineEntry): Promise<void> {
+		const fileName = this.getSessionFileName(sessionId);
+		const line = JSON.stringify(entry) + '\n';
+
+		// Read existing content and append
+		let existing = '';
+		try {
+			existing = await this.readText(fileName);
+		} catch {
+			// File doesn't exist yet
+		}
+
+		await this.writeText(fileName, existing + line);
+	}
+
+	/**
+	 * Append multiple timeline entries to a session file (batched write).
+	 */
+	async appendEntries(
+		sessionId: string,
+		entries: TimelineEntry[]
+	): Promise<void> {
+		if (entries.length === 0) return;
+
+		const fileName = this.getSessionFileName(sessionId);
+		const lines = entries.map((e) => JSON.stringify(e)).join('\n') + '\n';
+
+		// Read existing content and append
+		let existing = '';
+		try {
+			existing = await this.readText(fileName);
+		} catch {
+			// File doesn't exist yet
+		}
+
+		await this.writeText(fileName, existing + lines);
+	}
+
+	/**
+	 * Read all entries from a session.
+	 */
+	async readSession(sessionId: string): Promise<TimelineEntry[]> {
+		const fileName = this.getSessionFileName(sessionId);
+		try {
+			const content = await this.readText(fileName);
+			return content
+				.split('\n')
+				.filter((line) => line.trim())
+				.map((line) => JSON.parse(line) as TimelineEntry);
+		} catch {
+			return [];
+		}
+	}
+
+	/**
+	 * List all sessions.
+	 */
+	async listSessions(): Promise<TimelineSession[]> {
+		const index = await this.readIndex();
+		return index.sessions;
+	}
+
+	/**
+	 * Create a new session and add it to the index.
+	 * Automatically cleans up old sessions if over the limit.
+	 */
+	async createSession(session: TimelineSession): Promise<void> {
+		const index = await this.readIndex();
+		index.sessions.unshift(session);
+
+		// Cleanup old sessions if over limit
+		while (index.sessions.length > MAX_SESSIONS) {
+			const removed = index.sessions.pop()!;
+			await this.deleteSessionFile(removed.id);
+		}
+
+		await this.writeIndex(index);
+	}
+
+	/**
+	 * Update an existing session's metadata.
+	 */
+	async updateSession(
+		sessionId: string,
+		updates: Partial<TimelineSession>
+	): Promise<void> {
+		const index = await this.readIndex();
+		const session = index.sessions.find((s) => s.id === sessionId);
+		if (session) {
+			Object.assign(session, updates);
+			await this.writeIndex(index);
+		}
+	}
+
+	/**
+	 * Delete a specific session.
+	 */
+	async deleteSession(sessionId: string): Promise<void> {
+		const index = await this.readIndex();
+		const sessionIndex = index.sessions.findIndex(
+			(s) => s.id === sessionId
+		);
+		if (sessionIndex !== -1) {
+			index.sessions.splice(sessionIndex, 1);
+			await this.writeIndex(index);
+		}
+		await this.deleteSessionFile(sessionId);
+	}
+
+	/**
+	 * Clear all sessions.
+	 */
+	async clearAllSessions(): Promise<void> {
+		const index = await this.readIndex();
+		for (const session of index.sessions) {
+			await this.deleteSessionFile(session.id);
+		}
+		await this.writeIndex({ version: 1, sessions: [] });
+	}
+
+	// --- Private helpers ---
+
+	private getSessionFileName(sessionId: string): string {
+		return `session-${sessionId}.jsonl`;
+	}
+
+	private async readIndex(): Promise<SessionsIndex> {
+		try {
+			const content = await this.readText(SESSIONS_INDEX);
+			return JSON.parse(content) as SessionsIndex;
+		} catch {
+			return { version: 1, sessions: [] };
+		}
+	}
+
+	private async writeIndex(index: SessionsIndex): Promise<void> {
+		await this.writeJson(SESSIONS_INDEX, index);
+	}
+
+	private async deleteSessionFile(sessionId: string): Promise<void> {
+		const fileName = this.getSessionFileName(sessionId);
+		try {
+			await this.opfsRoot.removeEntry(fileName);
+		} catch {
+			// Ignore if file doesn't exist
+		}
+	}
+
+	private async fileExists(fileName: string): Promise<boolean> {
+		try {
+			await this.opfsRoot.getFileHandle(fileName);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	private async readText(fileName: string): Promise<string> {
+		const handle = await this.opfsRoot.getFileHandle(fileName);
+		const file = await handle.getFile();
+		return await file.text();
+	}
+
+	private async writeText(fileName: string, content: string): Promise<void> {
+		const handle = await this.opfsRoot.getFileHandle(fileName, {
+			create: true,
+		});
+		const writable = await handle.createWritable();
+		await writable.write(content);
+		await writable.close();
+	}
+
+	private async writeJson(fileName: string, data: unknown): Promise<void> {
+		await this.writeText(fileName, JSON.stringify(data, null, 2));
+	}
+}

--- a/packages/php-wasm/logger/src/test/debug-timeline.spec.ts
+++ b/packages/php-wasm/logger/src/test/debug-timeline.spec.ts
@@ -1,0 +1,180 @@
+import { DebugTimeline } from '../lib/timeline/debug-timeline';
+
+function createFakeDirectoryHandle() {
+	const files = new Map<string, string>();
+	const directories = new Map<
+		string,
+		ReturnType<typeof createFakeDirectoryHandle>
+	>();
+
+	return {
+		async getDirectoryHandle(
+			name: string,
+			options: { create?: boolean } = {}
+		) {
+			let directory = directories.get(name);
+			if (!directory) {
+				if (!options.create) {
+					throw new Error(`Directory not found: ${name}`);
+				}
+				directory = createFakeDirectoryHandle();
+				directories.set(name, directory);
+			}
+			return directory;
+		},
+		async getFileHandle(name: string, options: { create?: boolean } = {}) {
+			if (!files.has(name)) {
+				if (!options.create) {
+					throw new Error(`File not found: ${name}`);
+				}
+				files.set(name, '');
+			}
+
+			return {
+				async getFile() {
+					return {
+						text: async () => files.get(name) ?? '',
+					};
+				},
+				async createWritable() {
+					return {
+						write: async (content: string) => {
+							files.set(name, content);
+						},
+						close: async () => undefined,
+					};
+				},
+			};
+		},
+		async removeEntry(name: string) {
+			if (!files.delete(name) && !directories.delete(name)) {
+				throw new Error(`Entry not found: ${name}`);
+			}
+		},
+	};
+}
+
+describe('DebugTimeline', () => {
+	let root: ReturnType<typeof createFakeDirectoryHandle>;
+	let nextUUID = 1;
+
+	beforeEach(() => {
+		root = createFakeDirectoryHandle();
+		nextUUID = 1;
+
+		vi.stubGlobal('navigator', {
+			storage: {
+				getDirectory: vi.fn(async () => root),
+			},
+		});
+		vi.stubGlobal('crypto', {
+			randomUUID: vi.fn(() => `session-${nextUUID++}`),
+		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('stores timeline entries and filters verbose entries by default', async () => {
+		const timeline = new DebugTimeline({
+			verboseMode: false,
+			siteSlug: 'demo-site',
+			phpVersion: '8.3',
+			wpVersion: '6.8',
+		});
+
+		await timeline.initialize();
+		timeline.log({
+			category: 'runtime',
+			type: 'runtime.initialized',
+			message: 'Runtime initialized',
+		});
+		timeline.log({
+			category: 'filesystem',
+			type: 'filesystem.write',
+			message: 'Filesystem write',
+			verbose: true,
+		});
+
+		await timeline.endSession();
+
+		const currentSession = timeline.getCurrentSession();
+		expect(currentSession).toMatchObject({
+			id: 'session-1',
+			entryCount: 1,
+			siteSlug: 'demo-site',
+			phpVersion: '8.3',
+			wpVersion: '6.8',
+			verboseMode: false,
+		});
+
+		const sessions = await timeline.listSessions();
+		expect(sessions).toHaveLength(1);
+		expect(sessions[0]).toMatchObject({
+			id: 'session-1',
+			entryCount: 1,
+		});
+
+		const entries = await timeline.readSession('session-1');
+		expect(entries).toHaveLength(1);
+		expect(entries[0]).toMatchObject({
+			category: 'runtime',
+			type: 'runtime.initialized',
+			message: 'Runtime initialized',
+		});
+		expect(entries[0].timestamp).toMatch(
+			/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$/
+		);
+	});
+
+	it('includes buffered entries when reading the latest entries', async () => {
+		const timeline = new DebugTimeline({ verboseMode: true });
+		await timeline.initialize();
+
+		timeline.log({
+			category: 'blueprint',
+			type: 'blueprint.step.start',
+			message: 'Starting blueprint',
+		});
+
+		const latest = await timeline.readLatest(5);
+		expect(latest).toHaveLength(1);
+		expect(latest[0]).toMatchObject({
+			category: 'blueprint',
+			type: 'blueprint.step.start',
+			message: 'Starting blueprint',
+		});
+	});
+
+	it('exports sessions as jsonl, json, and csv', async () => {
+		const timeline = new DebugTimeline({ verboseMode: true });
+		await timeline.initialize();
+		timeline.log({
+			category: 'external',
+			type: 'external.request',
+			message: 'External call',
+			data: { method: 'debugLog.readLatest' },
+		});
+		await timeline.endSession();
+
+		const jsonl = await timeline.exportSession('session-1', 'jsonl');
+		expect(jsonl).toContain('"type":"external.request"');
+
+		const json = await timeline.exportSession('session-1', 'json');
+		expect(JSON.parse(json)).toMatchObject([
+			{
+				category: 'external',
+				type: 'external.request',
+				message: 'External call',
+			},
+		]);
+
+		const csv = await timeline.exportSession('session-1', 'csv');
+		expect(csv).toContain(
+			'timestamp,relativeMs,category,type,message,data'
+		);
+		expect(csv).toContain('"External call"');
+		expect(csv).toContain('"method"":""debugLog.readLatest"');
+	});
+});

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -8,9 +8,47 @@ import {
 	resolveRuntimeConfiguration,
 	BlueprintReflection,
 } from '.';
-import { collectPhpLogs, logger } from '@php-wasm/logger';
+import {
+	collectPhpLogs,
+	logger,
+	DebugTimeline,
+	collectPhpRuntimeEvents,
+	createBlueprintV1Callbacks,
+	collectNavigationEvents,
+} from '@php-wasm/logger';
+import type { DebugLogAPI } from '@wp-playground/remote';
 import { consumeAPI } from '@php-wasm/universal';
 import type { PHPWebExtension } from '@php-wasm/web';
+
+/**
+ * Check if debug timeline is enabled via query param.
+ */
+function getDebugLogConfig(): { enabled: boolean; verbose: boolean } {
+	if (typeof window === 'undefined') {
+		return { enabled: false, verbose: false };
+	}
+	const params = new URLSearchParams(window.location.search);
+	const debugLog = params.get('debug-log');
+	return {
+		enabled: debugLog === 'verbose' || debugLog === 'true',
+		verbose: debugLog === 'verbose',
+	};
+}
+
+/**
+ * Create the debugLog API from a DebugTimeline instance.
+ */
+function createDebugLogAPI(timeline: DebugTimeline): DebugLogAPI {
+	return {
+		listSessions: () => timeline.listSessions(),
+		readSession: (id: string) => timeline.readSession(id),
+		readLatest: (n?: number) => timeline.readLatest(n),
+		clearSessions: () => timeline.clearSessions(),
+		exportSession: (id: string, format?) =>
+			timeline.exportSession(id, format),
+		getCurrentSession: () => timeline.getCurrentSession(),
+	};
+}
 
 export class BlueprintsV1Handler {
 	private readonly options: StartPlaygroundOptions;
@@ -103,18 +141,77 @@ export class BlueprintsV1Handler {
 		downloadProgress.finish();
 
 		collectPhpLogs(logger, playground);
+
+		// Initialize debug timeline if enabled
+		const debugConfig = getDebugLogConfig();
+		let timeline: DebugTimeline | null = null;
+		if (debugConfig.enabled) {
+			timeline = new DebugTimeline({
+				verboseMode: debugConfig.verbose,
+				siteSlug: scope,
+				phpVersion: runtimeConfiguration.phpVersion,
+				wpVersion: runtimeConfiguration.wpVersion,
+			});
+			await timeline.initialize();
+
+			// Collect PHP runtime events
+			collectPhpRuntimeEvents(timeline, playground);
+
+			// Collect navigation events
+			collectNavigationEvents(timeline, playground as any);
+
+			// Log initial boot
+			timeline.log({
+				category: 'runtime',
+				type: 'runtime.initialized',
+				message: `Playground booted with PHP ${runtimeConfiguration.phpVersion}, WP ${runtimeConfiguration.wpVersion}`,
+				data: {
+					phpVersion: runtimeConfiguration.phpVersion,
+					wpVersion: runtimeConfiguration.wpVersion,
+					scope,
+				},
+			});
+
+			// Attach debugLog API to playground client
+			(playground as any).debugLog = createDebugLogAPI(timeline);
+		}
+
 		onClientConnected?.(playground);
 
 		const reflection = await BlueprintReflection.create(blueprint);
 		if (reflection.getVersion() === 1) {
+			// Create step callbacks that log to timeline
+			const timelineCallbacks = timeline
+				? createBlueprintV1Callbacks(timeline, {
+						onStepCompleted: onBlueprintStepCompleted,
+					})
+				: null;
+
 			const compiled = await compileBlueprintV1(blueprint, {
 				progress: executionProgress,
-				onStepCompleted: onBlueprintStepCompleted,
+				onStepCompleted:
+					timelineCallbacks?.onStepCompleted ||
+					onBlueprintStepCompleted,
 				onBlueprintValidated,
 				corsProxy,
 				gitAdditionalHeadersCallback,
 			});
+
+			// Log blueprint start
+			timeline?.log({
+				category: 'blueprint',
+				type: 'blueprint.step.start',
+				message: 'Starting blueprint execution',
+			});
+
 			await runBlueprintV1Steps(compiled, playground);
+
+			// Log blueprint completion
+			timeline?.log({
+				category: 'blueprint',
+				type: 'blueprint.step.finish',
+				message: 'Blueprint execution completed',
+			});
 		}
 
 		/**

--- a/packages/playground/client/src/blueprints-v2-handler.ts
+++ b/packages/playground/client/src/blueprints-v2-handler.ts
@@ -1,7 +1,45 @@
 import type { ProgressTracker } from '@php-wasm/progress';
 import type { PlaygroundClient, StartPlaygroundOptions } from '.';
-import { collectPhpLogs, logger } from '@php-wasm/logger';
+import {
+	collectPhpLogs,
+	logger,
+	DebugTimeline,
+	collectPhpRuntimeEvents,
+	collectBlueprintV2Events,
+	collectNavigationEvents,
+} from '@php-wasm/logger';
+import type { DebugLogAPI } from '@wp-playground/remote';
 import { consumeAPI } from '@php-wasm/universal';
+
+/**
+ * Check if debug timeline is enabled via query param.
+ */
+function getDebugLogConfig(): { enabled: boolean; verbose: boolean } {
+	if (typeof window === 'undefined') {
+		return { enabled: false, verbose: false };
+	}
+	const params = new URLSearchParams(window.location.search);
+	const debugLog = params.get('debug-log');
+	return {
+		enabled: debugLog === 'verbose' || debugLog === 'true',
+		verbose: debugLog === 'verbose',
+	};
+}
+
+/**
+ * Create the debugLog API from a DebugTimeline instance.
+ */
+function createDebugLogAPI(timeline: DebugTimeline): DebugLogAPI {
+	return {
+		listSessions: () => timeline.listSessions(),
+		readSession: (id: string) => timeline.readSession(id),
+		readLatest: (n?: number) => timeline.readLatest(n),
+		clearSessions: () => timeline.clearSessions(),
+		exportSession: (id: string, format?) =>
+			timeline.exportSession(id, format),
+		getCurrentSession: () => timeline.getCurrentSession(),
+	};
+}
 
 export class BlueprintsV2Handler {
 	private readonly options: StartPlaygroundOptions;
@@ -104,6 +142,37 @@ export class BlueprintsV2Handler {
 		downloadProgress.finish();
 
 		collectPhpLogs(logger, playground);
+
+		// Initialize debug timeline if enabled
+		const debugConfig = getDebugLogConfig();
+		if (debugConfig.enabled) {
+			const timeline = new DebugTimeline({
+				verboseMode: debugConfig.verbose,
+				siteSlug: scope,
+			});
+			await timeline.initialize();
+
+			// Collect PHP runtime events
+			collectPhpRuntimeEvents(timeline, playground);
+
+			// Collect Blueprint V2 message events
+			collectBlueprintV2Events(timeline, playground as any);
+
+			// Collect navigation events
+			collectNavigationEvents(timeline, playground as any);
+
+			// Log initial boot
+			timeline.log({
+				category: 'runtime',
+				type: 'runtime.initialized',
+				message: 'Playground booted (Blueprints V2 mode)',
+				data: { scope },
+			});
+
+			// Attach debugLog API to playground client
+			(playground as any).debugLog = createDebugLogAPI(timeline);
+		}
+
 		onClientConnected?.(playground);
 
 		// @TODO: Get the landing page from the Blueprint.

--- a/packages/playground/remote/src/lib/playground-client.ts
+++ b/packages/playground/remote/src/lib/playground-client.ts
@@ -10,6 +10,30 @@ import type {
 	MountDescriptor,
 	WorkerBootOptions,
 } from './playground-worker-endpoint';
+import type {
+	TimelineEntry,
+	TimelineSession,
+	TimelineExportFormat,
+} from '@php-wasm/logger';
+
+/**
+ * Debug log API for accessing the debug timeline.
+ * Only available when ?debug-log=verbose query param is set.
+ */
+export interface DebugLogAPI {
+	/** Get all available sessions */
+	listSessions(): Promise<TimelineSession[]>;
+	/** Read all entries from a specific session */
+	readSession(id: string): Promise<TimelineEntry[]>;
+	/** Read the latest n entries from the current session */
+	readLatest(n?: number): Promise<TimelineEntry[]>;
+	/** Clear all sessions */
+	clearSessions(): Promise<void>;
+	/** Export a session in the specified format */
+	exportSession(id: string, format?: TimelineExportFormat): Promise<string>;
+	/** Get the current session info */
+	getCurrentSession(): TimelineSession | null;
+}
 
 export interface WebClientMixin extends ProgressReceiver {
 	/**
@@ -71,6 +95,12 @@ export interface WebClientMixin extends ProgressReceiver {
 	unmountOpfs(mountpoint: string): Promise<void>;
 
 	boot(options: WorkerBootOptions): Promise<void>;
+
+	/**
+	 * Debug timeline API for developers.
+	 * Only available when ?debug-log=verbose query param is set.
+	 */
+	debugLog?: DebugLogAPI;
 }
 
 /**

--- a/packages/playground/website/src/components/debug-timeline/index.tsx
+++ b/packages/playground/website/src/components/debug-timeline/index.tsx
@@ -1,0 +1,254 @@
+import { useEffect, useState, useCallback } from 'react';
+import { usePlaygroundClient } from '../../lib/use-playground-client';
+import type {
+	TimelineEntry,
+	TimelineSession,
+	TimelineExportFormat,
+} from '@php-wasm/logger';
+import type { DebugLogAPI } from '@wp-playground/remote';
+import css from './style.module.css';
+import classNames from 'classnames';
+
+interface TimelineEntryRowProps {
+	entry: TimelineEntry;
+}
+
+const categoryColors: Record<string, string> = {
+	blueprint: css.categoryBlueprint,
+	php: css.categoryPhp,
+	navigation: css.categoryNavigation,
+	runtime: css.categoryRuntime,
+	filesystem: css.categoryFilesystem,
+	external: css.categoryExternal,
+};
+
+function TimelineEntryRow({ entry }: TimelineEntryRowProps) {
+	const formattedTime = entry.timestamp.replace('T', ' ').replace('Z', '');
+
+	return (
+		<div
+			className={classNames(
+				css.entryRow,
+				categoryColors[entry.category] || ''
+			)}
+		>
+			<span className={css.timestamp}>[{formattedTime}]</span>
+			<span className={css.category}>{entry.category}</span>
+			<span className={css.type}>{entry.type}</span>
+			<span className={css.message}>{entry.message}</span>
+			{entry.data && Object.keys(entry.data).length > 0 && (
+				<details className={css.dataExpander}>
+					<summary>Data</summary>
+					<pre>{JSON.stringify(entry.data, null, 2)}</pre>
+				</details>
+			)}
+		</div>
+	);
+}
+
+interface SessionSelectorProps {
+	sessions: TimelineSession[];
+	selectedId: string | null;
+	onSelect: (id: string | null) => void;
+}
+
+function SessionSelector({
+	sessions,
+	selectedId,
+	onSelect,
+}: SessionSelectorProps) {
+	if (sessions.length === 0) {
+		return null;
+	}
+
+	return (
+		<select
+			className={css.sessionSelect}
+			value={selectedId || ''}
+			onChange={(e) => onSelect(e.target.value || null)}
+		>
+			{sessions.map((session) => {
+				const date = new Date(session.startTime);
+				const label = `${date.toLocaleDateString()} ${date.toLocaleTimeString()} (${session.entryCount} entries)`;
+				return (
+					<option key={session.id} value={session.id}>
+						{label}
+					</option>
+				);
+			})}
+		</select>
+	);
+}
+
+export function DebugTimelineView() {
+	const client = usePlaygroundClient();
+	const [sessions, setSessions] = useState<TimelineSession[]>([]);
+	const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
+		null
+	);
+	const [entries, setEntries] = useState<TimelineEntry[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [filter, setFilter] = useState('');
+	const [debugLog, setDebugLog] = useState<DebugLogAPI | null>(null);
+
+	// Resolve the debugLog property which might be a Promise or direct value
+	useEffect(() => {
+		if (!client) {
+			setLoading(false);
+			return;
+		}
+
+		// The debugLog property is set directly on the client, not through Comlink,
+		// but TypeScript thinks it might be wrapped. We access it directly.
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const maybeDebugLog = (client as any).debugLog;
+		if (!maybeDebugLog) {
+			setLoading(false);
+			return;
+		}
+
+		// Check if it's a Promise or direct object
+		if (typeof maybeDebugLog.then === 'function') {
+			maybeDebugLog.then((resolved: DebugLogAPI | undefined) => {
+				setDebugLog(resolved || null);
+				setLoading(false);
+			});
+		} else {
+			setDebugLog(maybeDebugLog);
+			setLoading(false);
+		}
+	}, [client]);
+
+	useEffect(() => {
+		if (!debugLog) return;
+
+		debugLog.listSessions().then((sessionList: TimelineSession[]) => {
+			setSessions(sessionList);
+			if (sessionList.length > 0) {
+				setSelectedSessionId(sessionList[0].id);
+			}
+		});
+	}, [debugLog]);
+
+	useEffect(() => {
+		if (!debugLog || !selectedSessionId) return;
+
+		debugLog.readSession(selectedSessionId).then(setEntries);
+	}, [debugLog, selectedSessionId]);
+
+	// Periodically refresh entries for the current session
+	useEffect(() => {
+		if (!debugLog || !selectedSessionId) return;
+
+		const interval = setInterval(async () => {
+			const currentSession = debugLog.getCurrentSession();
+			if (currentSession && currentSession.id === selectedSessionId) {
+				const newEntries =
+					await debugLog.readSession(selectedSessionId);
+				setEntries(newEntries);
+			}
+		}, 2000);
+
+		return () => clearInterval(interval);
+	}, [debugLog, selectedSessionId]);
+
+	const handleExport = useCallback(
+		async (format: TimelineExportFormat) => {
+			if (!debugLog || !selectedSessionId) return;
+
+			const content = await debugLog.exportSession(
+				selectedSessionId,
+				format
+			);
+			const blob = new Blob([content], { type: 'text/plain' });
+			const url = URL.createObjectURL(blob);
+			const a = document.createElement('a');
+			a.href = url;
+			a.download = `debug-timeline-${selectedSessionId}.${format}`;
+			a.click();
+			URL.revokeObjectURL(url);
+		},
+		[debugLog, selectedSessionId]
+	);
+
+	const handleClear = useCallback(async () => {
+		if (!debugLog) return;
+		if (
+			!window.confirm(
+				'Are you sure you want to clear all debug timeline sessions?'
+			)
+		) {
+			return;
+		}
+		await debugLog.clearSessions();
+		setSessions([]);
+		setEntries([]);
+		setSelectedSessionId(null);
+	}, [debugLog]);
+
+	const filteredEntries = entries.filter(
+		(entry) =>
+			!filter ||
+			entry.message.toLowerCase().includes(filter.toLowerCase()) ||
+			entry.type.toLowerCase().includes(filter.toLowerCase()) ||
+			entry.category.toLowerCase().includes(filter.toLowerCase())
+	);
+
+	if (loading) {
+		return <div className={css.loading}>Loading timeline...</div>;
+	}
+
+	if (!debugLog) {
+		return (
+			<div className={css.notEnabled}>
+				Debug Timeline is not enabled.
+				<br />
+				<br />
+				Add <code>?debug-log=verbose</code> to the URL to enable it.
+			</div>
+		);
+	}
+
+	return (
+		<div className={css.timelineContainer}>
+			<div className={css.toolbar}>
+				<SessionSelector
+					sessions={sessions}
+					selectedId={selectedSessionId}
+					onSelect={setSelectedSessionId}
+				/>
+				<input
+					type="text"
+					placeholder="Filter entries..."
+					value={filter}
+					onChange={(e) => setFilter(e.target.value)}
+					className={css.filterInput}
+				/>
+				<div className={css.actions}>
+					<button onClick={() => handleExport('jsonl')}>JSONL</button>
+					<button onClick={() => handleExport('json')}>JSON</button>
+					<button onClick={() => handleExport('csv')}>CSV</button>
+					<button onClick={handleClear} className={css.dangerButton}>
+						Clear All
+					</button>
+				</div>
+			</div>
+
+			<div className={css.entriesList}>
+				{filteredEntries.length === 0 ? (
+					<div className={css.emptyState}>
+						{entries.length === 0
+							? 'No timeline entries yet. Perform some actions to see events.'
+							: 'No entries match the filter.'}
+					</div>
+				) : (
+					filteredEntries.map((entry, index) => (
+						<TimelineEntryRow key={index} entry={entry} />
+					))
+				)}
+			</div>
+		</div>
+	);
+}
+
+export default DebugTimelineView;

--- a/packages/playground/website/src/components/debug-timeline/style.module.css
+++ b/packages/playground/website/src/components/debug-timeline/style.module.css
@@ -1,0 +1,221 @@
+.timelineContainer {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	width: 100%;
+	padding: 1rem;
+}
+
+.toolbar {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	margin-bottom: 1rem;
+	align-items: center;
+}
+
+.sessionSelect {
+	min-width: 200px;
+}
+
+.filterInput {
+	flex: 1;
+	min-width: 150px;
+	padding: 0.5rem;
+	border: 1px solid #ccc;
+	border-radius: 4px;
+}
+
+.actions {
+	display: flex;
+	gap: 0.25rem;
+}
+
+.actions button {
+	padding: 0.5rem 0.75rem;
+	border: 1px solid #ccc;
+	background: #f0f0f0;
+	border-radius: 4px;
+	cursor: pointer;
+	font-size: 0.875rem;
+}
+
+.actions button:hover {
+	background: #e0e0e0;
+}
+
+.dangerButton {
+	color: #c00;
+	border-color: #c00 !important;
+}
+
+.dangerButton:hover {
+	background: #fee !important;
+}
+
+.entriesList {
+	flex: 1;
+	overflow-y: auto;
+	border: 1px solid #ddd;
+	border-radius: 4px;
+	font-family: monospace;
+	font-size: 0.875rem;
+}
+
+.emptyState,
+.notEnabled,
+.loading {
+	padding: 2rem;
+	text-align: center;
+	color: #666;
+}
+
+.notEnabled code {
+	background: #f0f0f0;
+	padding: 0.25rem 0.5rem;
+	border-radius: 4px;
+	font-family: monospace;
+}
+
+/* Entry row styles */
+.entryRow {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	padding: 0.5rem;
+	border-bottom: 1px solid #eee;
+	align-items: flex-start;
+}
+
+.entryRow:hover {
+	background: #f9f9f9;
+}
+
+.timestamp {
+	color: #666;
+	flex-shrink: 0;
+	font-size: 0.75rem;
+}
+
+.category {
+	padding: 0.125rem 0.5rem;
+	border-radius: 3px;
+	font-size: 0.75rem;
+	font-weight: 500;
+	text-transform: uppercase;
+	flex-shrink: 0;
+}
+
+.type {
+	color: #333;
+	font-weight: 500;
+	flex-shrink: 0;
+}
+
+.message {
+	flex: 1;
+	word-break: break-word;
+}
+
+.dataExpander {
+	width: 100%;
+	margin-top: 0.25rem;
+}
+
+.dataExpander summary {
+	cursor: pointer;
+	color: #666;
+	font-size: 0.75rem;
+}
+
+.dataExpander pre {
+	margin: 0.25rem 0 0 0;
+	padding: 0.5rem;
+	background: #f5f5f5;
+	border-radius: 4px;
+	overflow-x: auto;
+	font-size: 0.75rem;
+}
+
+/* Category colors */
+.categoryBlueprint {
+	border-left: 3px solid #3498db;
+}
+
+.categoryBlueprint .category {
+	background: #ebf5fb;
+	color: #2980b9;
+}
+
+.categoryPhp {
+	border-left: 3px solid #9b59b6;
+}
+
+.categoryPhp .category {
+	background: #f5eef8;
+	color: #8e44ad;
+}
+
+.categoryNavigation {
+	border-left: 3px solid #27ae60;
+}
+
+.categoryNavigation .category {
+	background: #e9f7ef;
+	color: #1e8449;
+}
+
+.categoryRuntime {
+	border-left: 3px solid #f39c12;
+}
+
+.categoryRuntime .category {
+	background: #fef9e7;
+	color: #d68910;
+}
+
+.categoryFilesystem {
+	border-left: 3px solid #95a5a6;
+}
+
+.categoryFilesystem .category {
+	background: #f4f6f6;
+	color: #717d7e;
+}
+
+.categoryExternal {
+	border-left: 3px solid #e74c3c;
+}
+
+.categoryExternal .category {
+	background: #fdedec;
+	color: #c0392b;
+}
+
+/* Tabs */
+.tabs {
+	display: flex;
+	border-bottom: 1px solid #ddd;
+	margin-bottom: 1rem;
+}
+
+.tab {
+	padding: 0.75rem 1rem;
+	border: none;
+	background: none;
+	cursor: pointer;
+	font-size: 1rem;
+	color: #666;
+	border-bottom: 2px solid transparent;
+	margin-bottom: -1px;
+}
+
+.tab:hover {
+	color: #333;
+}
+
+.tabActive {
+	color: #3498db;
+	border-bottom-color: #3498db;
+	font-weight: 500;
+}

--- a/packages/playground/website/src/components/log-modal/index.tsx
+++ b/packages/playground/website/src/components/log-modal/index.tsx
@@ -11,21 +11,62 @@ import type {
 } from '../../lib/state/redux/store';
 import { useDispatch, useSelector } from 'react-redux';
 import { setActiveModal } from '../../lib/state/redux/slice-ui';
+import { DebugTimelineView } from '../debug-timeline';
+import { usePlaygroundClient } from '../../lib/use-playground-client';
+
+type LogModalTab = 'logs' | 'timeline';
 
 export function LogModal(props: { description?: JSX.Element; title?: string }) {
 	const activeModal = useSelector(
 		(state: PlaygroundReduxState) => state.ui.activeModal
 	);
 	const dispatch: PlaygroundDispatch = useDispatch();
+	const [activeTab, setActiveTab] = useState<LogModalTab>('logs');
+	const client = usePlaygroundClient();
+
+	// Check if debug timeline is available
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const hasDebugTimeline = !!(client as any)?.debugLog;
+	const showTimeline = hasDebugTimeline && activeTab === 'timeline';
 
 	function onClose() {
 		dispatch(setActiveModal(null));
 	}
 
 	return (
-		<Modal title={props.title || 'Error Logs'} onRequestClose={onClose}>
+		<Modal
+			title={
+				props.title ||
+				(hasDebugTimeline ? 'Logs & Timeline' : 'Error Logs')
+			}
+			onRequestClose={onClose}
+		>
 			<div>{props.description}</div>
-			<SiteLogs key={activeModal} className={css.logsInsideModal} />
+			{hasDebugTimeline && (
+				<div className={css.tabs}>
+					<button
+						className={classNames(css.tab, {
+							[css.tabActive]: activeTab === 'logs',
+						})}
+						onClick={() => setActiveTab('logs')}
+					>
+						Error Logs
+					</button>
+					<button
+						className={classNames(css.tab, {
+							[css.tabActive]: activeTab === 'timeline',
+						})}
+						onClick={() => setActiveTab('timeline')}
+					>
+						Debug Timeline
+					</button>
+				</div>
+			)}
+			{showTimeline ? (
+				<DebugTimelineView />
+			) : (
+				<SiteLogs key={activeModal} className={css.logsInsideModal} />
+			)}
 		</Modal>
 	);
 }

--- a/packages/playground/website/src/components/log-modal/style.module.css
+++ b/packages/playground/website/src/components/log-modal/style.module.css
@@ -37,3 +37,31 @@
 .log__entry:has(mark) {
 	background-color: ivory;
 }
+
+/* Tabs for switching between logs and timeline */
+.tabs {
+	display: flex;
+	border-bottom: 1px solid #ddd;
+	margin-bottom: 1rem;
+}
+
+.tab {
+	padding: 0.75rem 1rem;
+	border: none;
+	background: none;
+	cursor: pointer;
+	font-size: 1rem;
+	color: #666;
+	border-bottom: 2px solid transparent;
+	margin-bottom: -1px;
+}
+
+.tab:hover {
+	color: #333;
+}
+
+.tab-active {
+	color: #3498db;
+	border-bottom-color: #3498db;
+	font-weight: 500;
+}


### PR DESCRIPTION
Add a timed debug timeline feature for Playground developers and integrators. Enabled via `?debug-log=verbose` or `?debug-log=true`.

Features:
- Structured timeline entries with timestamps, categories, and event types.
- OPFS persistence with automatic cleanup of old sessions.
- Event collection for PHP runtime, Blueprint steps, and navigation.
- Website UI with a Debug Timeline tab in `LogModal`, session selection, filtering, and export.
- API exposure via `playground.debugLog.*` for programmatic access.

## Refresh Notes
- Rebased onto current fork `trunk` / upstream `trunk` (`dac72f5b4`).
- Replaced direct `console.warn()` calls in the timeline module with the existing `@php-wasm/logger` logger so package lint passes with zero warnings.
- Removed an inferred numeric type annotation that failed lint.
- Added focused `DebugTimeline` tests for OPFS-backed session storage, verbose filtering, latest-entry reads, and json/jsonl/csv export.
- Guarded the LogModal timeline rendering so it falls back to logs if the timeline tab was selected but the debug API becomes unavailable.

## Validation
- `git diff --check HEAD~1 HEAD`
- `npx prettier --check` on changed logger/client/remote/website files
- `npx nx run-many --target=lint --projects=php-wasm-logger,playground-client,playground-remote,playground-website --skip-nx-cache`
- `npx nx run-many --target=typecheck --projects=php-wasm-logger,playground-client,playground-remote,playground-website --skip-nx-cache`
- `npx nx run php-wasm-logger:test --skip-nx-cache`

## Local Caveats
- A later broad `run-many --target=test` attempt passed `php-wasm-logger`, `playground-client`, and `playground-website`, but `playground-remote:test` timed out in unchanged worker/OPFS specs under local CPU/I/O pressure. The same remote target had passed earlier in this branch before the final logger/UI-only patches, so this is not treated as a debug timeline regression.
- A local `playground-website:build --skip-nx-cache` run progressed through the major dependency builds and website-extras, but the session ended before a final exit code was captured. GitHub CI is queued for the authoritative full build result.

Current head: `0e911edc1e2a875d11cf387316336d0979f3bf84`.