### PR TITLE
Narrow DevTools extension host permissions

### DIFF
--- a/packages/playground/devtools-extension/project.json
+++ b/packages/playground/devtools-extension/project.json
@@ -41,6 +41,17 @@
 					"tsc -p packages/playground/devtools-extension/tsconfig.lib.json --noEmit"
 				]
 			}
+		},
+		"test": {
+			"executor": "@nx/vitest:test",
+			"outputs": [
+				"{workspaceRoot}/coverage/packages/playground/devtools-extension"
+			],
+			"options": {
+				"config": "packages/playground/devtools-extension/vitest.config.ts",
+				"passWithNoTests": true,
+				"reportsDirectory": "../../../coverage/packages/playground/devtools-extension"
+			}
 		}
 	},
 	"tags": []

--- a/packages/playground/devtools-extension/public/manifest.json
+++ b/packages/playground/devtools-extension/public/manifest.json
@@ -10,14 +10,31 @@
 	},
 	"devtools_page": "devtools/index.html",
 	"permissions": ["scripting", "activeTab", "webNavigation"],
-	"host_permissions": ["<all_urls>"],
+	"host_permissions": [
+		"*://playground.wordpress.net/*",
+		"*://developer.wordpress.org/*",
+		"*://developer.woocommerce.com/*",
+		"*://developer.wordpress.com/*",
+		"*://wordpress.org/*",
+		"*://localhost/*",
+		"*://127.0.0.1/*"
+	],
+	"optional_host_permissions": ["http://*/*", "https://*/*"],
 	"background": {
 		"service_worker": "background.js",
 		"type": "module"
 	},
 	"content_scripts": [
 		{
-			"matches": ["<all_urls>"],
+			"matches": [
+				"*://playground.wordpress.net/*",
+				"*://developer.wordpress.org/*",
+				"*://developer.woocommerce.com/*",
+				"*://developer.wordpress.com/*",
+				"*://wordpress.org/*",
+				"*://localhost/*",
+				"*://127.0.0.1/*"
+			],
 			"js": ["content-script.js"],
 			"run_at": "document_idle",
 			"all_frames": true

--- a/packages/playground/devtools-extension/src/background.ts
+++ b/packages/playground/devtools-extension/src/background.ts
@@ -5,6 +5,15 @@
  * and tracks which frames have playground instances.
  */
 
+import {
+	getHostname,
+	getOrigin,
+	getOriginPattern,
+	hasPermissionForUrl,
+	isAllowlistedUrl,
+	isSupportedUrl,
+} from './permissions';
+
 interface PlaygroundFrame {
 	frameId: number;
 	tabId: number;
@@ -13,11 +22,278 @@ interface PlaygroundFrame {
 	documentRoot?: string;
 }
 
+interface FrameAccess {
+	frameId: number;
+	parentFrameId: number;
+	url: string;
+	origin: string;
+	originPattern: string | null;
+	hostname: string;
+	isSupported: boolean;
+	isAllowlisted: boolean;
+	hasPermission: boolean;
+	canRequestPermission: boolean;
+}
+
+interface InjectionResult {
+	frameId: number;
+	url: string;
+	injected: boolean;
+	error?: string;
+}
+
 // Store playground frames per tab
 const playgroundFrames = new Map<number, Map<number, PlaygroundFrame>>();
 
 // Store connections to DevTools panels
 const devToolsConnections = new Map<number, chrome.runtime.Port>();
+
+function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function getDetectedPlaygroundFrames(tabId: number): PlaygroundFrame[] {
+	return Array.from(playgroundFrames.get(tabId)?.values() ?? []).filter(
+		(frame) => frame.hasPlayground
+	);
+}
+
+function getDynamicContentScriptId(originPattern: string): string {
+	return `wp-playground-devtools-${originPattern
+		.replace(/[^a-zA-Z0-9_]/g, '_')
+		.slice(0, 80)}`;
+}
+
+function canRegisterDynamicContentScript(originPattern: string): boolean {
+	return (
+		originPattern === '<all_urls>' ||
+		originPattern.startsWith('http://') ||
+		originPattern.startsWith('https://')
+	);
+}
+
+async function registerDynamicContentScript(originPattern: string) {
+	if (!canRegisterDynamicContentScript(originPattern)) {
+		return;
+	}
+
+	const id = getDynamicContentScriptId(originPattern);
+	const existing = await chrome.scripting.getRegisteredContentScripts({
+		ids: [id],
+	});
+
+	if (existing.length > 0) {
+		return;
+	}
+
+	try {
+		await chrome.scripting.registerContentScripts([
+			{
+				id,
+				matches: [originPattern],
+				js: ['content-script.js'],
+				runAt: 'document_idle',
+				allFrames: true,
+				matchOriginAsFallback: true,
+				persistAcrossSessions: true,
+			},
+		]);
+	} catch (error) {
+		const existingAfterError =
+			await chrome.scripting.getRegisteredContentScripts({
+				ids: [id],
+			});
+		if (existingAfterError.length === 0) {
+			throw error;
+		}
+	}
+}
+
+async function unregisterDynamicContentScripts(originPatterns: string[]) {
+	const ids = originPatterns
+		.filter(canRegisterDynamicContentScript)
+		.map(getDynamicContentScriptId);
+
+	if (ids.length === 0) {
+		return;
+	}
+
+	await chrome.scripting.unregisterContentScripts({ ids });
+}
+
+async function syncDynamicContentScripts() {
+	try {
+		const permissions = await chrome.permissions.getAll();
+		await Promise.all(
+			(permissions.origins ?? []).map(registerDynamicContentScript)
+		);
+	} catch (error) {
+		// eslint-disable-next-line no-console
+		console.debug('Failed to sync dynamic content scripts:', error);
+	}
+}
+
+async function getFrameAccess(tabId: number): Promise<FrameAccess[]> {
+	const frames = await chrome.webNavigation.getAllFrames({ tabId });
+	if (!frames) {
+		return [];
+	}
+
+	return Promise.all(
+		frames.map(async (frame) => {
+			const originPattern = getOriginPattern(frame.url);
+			const isSupported = isSupportedUrl(frame.url);
+			const isAllowlisted = isAllowlistedUrl(frame.url);
+			const hasPermission =
+				isSupported &&
+				(isAllowlisted || (await hasPermissionForUrl(frame.url)));
+
+			return {
+				frameId: frame.frameId,
+				parentFrameId: frame.parentFrameId,
+				url: frame.url,
+				origin: getOrigin(frame.url),
+				originPattern,
+				hostname: getHostname(frame.url),
+				isSupported,
+				isAllowlisted,
+				hasPermission,
+				canRequestPermission: isSupported && !isAllowlisted,
+			};
+		})
+	);
+}
+
+async function postFrameState(
+	tabId: number,
+	injectionResults?: InjectionResult[]
+) {
+	const port = devToolsConnections.get(tabId);
+	if (!port) {
+		return;
+	}
+
+	port.postMessage({
+		type: 'FRAMES_UPDATED',
+		frames: getDetectedPlaygroundFrames(tabId),
+		frameAccess: await getFrameAccess(tabId),
+		injectionResults,
+	});
+}
+
+function recordPlaygroundFrame(
+	tabId: number,
+	frameId: number,
+	response: {
+		url: string;
+		hasPlayground: boolean;
+		documentRoot?: string;
+	}
+) {
+	const frames = playgroundFrames.get(tabId) ?? new Map();
+	frames.set(frameId, {
+		frameId,
+		tabId,
+		url: response.url,
+		hasPlayground: response.hasPlayground,
+		documentRoot: response.documentRoot,
+	});
+	playgroundFrames.set(tabId, frames);
+}
+
+async function refreshFrame(tabId: number, frameId: number) {
+	try {
+		const response = await chrome.tabs.sendMessage(
+			tabId,
+			{ type: 'CHECK_PLAYGROUND' },
+			{ frameId }
+		);
+
+		if (response) {
+			recordPlaygroundFrame(tabId, frameId, response);
+		}
+	} catch {
+		// No content script is available in this frame.
+	}
+}
+
+async function refreshTabFrames(tabId: number) {
+	const frameAccess = await getFrameAccess(tabId);
+	const activeFrameIds = new Set(frameAccess.map((frame) => frame.frameId));
+	const tabFrames = playgroundFrames.get(tabId);
+
+	if (tabFrames) {
+		for (const frameId of tabFrames.keys()) {
+			if (!activeFrameIds.has(frameId)) {
+				tabFrames.delete(frameId);
+			}
+		}
+	}
+
+	await Promise.all(
+		frameAccess
+			.filter((frame) => frame.hasPermission)
+			.map((frame) => refreshFrame(tabId, frame.frameId))
+	);
+
+	await postFrameState(tabId);
+}
+
+async function injectContentScript(
+	tabId: number,
+	originPattern?: string
+): Promise<InjectionResult[]> {
+	const frameAccess = await getFrameAccess(tabId);
+	const framesToInject = frameAccess.filter(
+		(frame) =>
+			frame.hasPermission &&
+			(!originPattern ||
+				originPattern === '<all_urls>' ||
+				frame.originPattern === originPattern)
+	);
+
+	const results = await Promise.all(
+		framesToInject.map(async (frame): Promise<InjectionResult> => {
+			try {
+				await chrome.scripting.executeScript({
+					target: { tabId, frameIds: [frame.frameId] },
+					files: ['content-script.js'],
+				});
+				return {
+					frameId: frame.frameId,
+					url: frame.url,
+					injected: true,
+				};
+			} catch (error) {
+				return {
+					frameId: frame.frameId,
+					url: frame.url,
+					injected: false,
+					error: getErrorMessage(error),
+				};
+			}
+		})
+	);
+
+	await Promise.all(
+		results
+			.filter((result) => result.injected)
+			.map((result) => refreshFrame(tabId, result.frameId))
+	);
+	await postFrameState(tabId, results);
+
+	return results;
+}
+
+async function registerAndInjectHostPermission(tabId: number, url: string) {
+	const originPattern = getOriginPattern(url);
+	if (originPattern) {
+		await registerDynamicContentScript(originPattern);
+	}
+
+	await injectContentScript(tabId, originPattern ?? undefined);
+	await refreshTabFrames(tabId);
+}
 
 /**
  * Handle messages from content scripts.
@@ -27,29 +303,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 		const tabId = sender.tab.id;
 		const frameId = sender.frameId ?? 0;
 
-		if (!playgroundFrames.has(tabId)) {
-			playgroundFrames.set(tabId, new Map());
-		}
-
-		const frames = playgroundFrames.get(tabId)!;
-		frames.set(frameId, {
-			frameId,
-			tabId,
+		recordPlaygroundFrame(tabId, frameId, {
 			url: message.url,
 			hasPlayground: message.hasPlayground,
 			documentRoot: message.documentRoot,
 		});
 
-		// Notify the DevTools panel for this tab if connected
-		const port = devToolsConnections.get(tabId);
-		if (port) {
-			port.postMessage({
-				type: 'FRAMES_UPDATED',
-				frames: Array.from(frames.values()).filter(
-					(f) => f.hasPlayground
-				),
-			});
-		}
+		void postFrameState(tabId);
 		return false;
 	}
 
@@ -171,66 +431,23 @@ chrome.runtime.onConnect.addListener((port) => {
 			}
 			devToolsConnections.set(tabId, port);
 
-			// Send current frames to the newly connected panel
-			const frames = playgroundFrames.get(tabId);
-			if (frames) {
-				port.postMessage({
-					type: 'FRAMES_UPDATED',
-					frames: Array.from(frames.values()).filter(
-						(f) => f.hasPlayground
-					),
-				});
-			}
+			void (async () => {
+				await syncDynamicContentScripts();
+				await injectContentScript(tabId!);
+				await refreshTabFrames(tabId!);
+			})();
 		}
 
 		if (message.type === 'REFRESH_FRAMES' && tabId !== null) {
-			// Request all frames in the tab to re-check for playground
-			chrome.tabs
-				.sendMessage(
-					tabId,
-					{ type: 'CHECK_PLAYGROUND' },
-					{ frameId: 0 }
-				)
-				.catch(() => {});
+			void refreshTabFrames(tabId);
+		}
 
-			// Also query all frames
-			chrome.webNavigation.getAllFrames({ tabId }).then((frames) => {
-				if (!frames) return;
-
-				frames.forEach((frame) => {
-					chrome.tabs
-						.sendMessage(
-							tabId!,
-							{ type: 'CHECK_PLAYGROUND' },
-							{ frameId: frame.frameId }
-						)
-						.then((response) => {
-							if (response) {
-								const tabFrames =
-									playgroundFrames.get(tabId!) ?? new Map();
-								tabFrames.set(frame.frameId, {
-									frameId: frame.frameId,
-									tabId: tabId!,
-									url: response.url,
-									hasPlayground: response.hasPlayground,
-									documentRoot: response.documentRoot,
-								});
-								playgroundFrames.set(tabId!, tabFrames);
-
-								const port = devToolsConnections.get(tabId!);
-								if (port) {
-									port.postMessage({
-										type: 'FRAMES_UPDATED',
-										frames: Array.from(
-											tabFrames.values()
-										).filter((f) => f.hasPlayground),
-									});
-								}
-							}
-						})
-						.catch(() => {});
-				});
-			});
+		if (
+			(message.type === 'HOST_PERMISSION_GRANTED' ||
+				message.type === 'INJECT_CONTENT_SCRIPT') &&
+			tabId !== null
+		) {
+			void registerAndInjectHostPermission(tabId, message.url);
 		}
 
 		if (message.type === 'EXECUTE_METHOD' && tabId !== null) {
@@ -269,6 +486,31 @@ chrome.runtime.onConnect.addListener((port) => {
 	});
 });
 
+chrome.permissions.onAdded.addListener((permissions) => {
+	void Promise.all(
+		(permissions.origins ?? []).map(registerDynamicContentScript)
+	);
+});
+
+chrome.permissions.onRemoved.addListener((permissions) => {
+	void (async () => {
+		await unregisterDynamicContentScripts(permissions.origins ?? []);
+		for (const tabId of devToolsConnections.keys()) {
+			await refreshTabFrames(tabId);
+		}
+	})();
+});
+
+chrome.runtime.onInstalled.addListener(() => {
+	void syncDynamicContentScripts();
+});
+
+chrome.runtime.onStartup.addListener(() => {
+	void syncDynamicContentScripts();
+});
+
+void syncDynamicContentScripts();
+
 // Clean up when tabs are closed
 chrome.tabs.onRemoved.addListener((tabId) => {
 	playgroundFrames.delete(tabId);
@@ -287,4 +529,17 @@ chrome.webNavigation.onBeforeNavigate.addListener((details) => {
 			frames.delete(details.frameId);
 		}
 	}
+
+	void postFrameState(details.tabId);
+});
+
+chrome.webNavigation.onCompleted.addListener((details) => {
+	if (!devToolsConnections.has(details.tabId)) {
+		return;
+	}
+
+	void (async () => {
+		await injectContentScript(details.tabId);
+		await refreshTabFrames(details.tabId);
+	})();
 });

--- a/packages/playground/devtools-extension/src/content-script.ts
+++ b/packages/playground/devtools-extension/src/content-script.ts
@@ -42,30 +42,40 @@ async function reportPlaygroundStatus() {
 	});
 }
 
-// Check immediately when the script loads
-reportPlaygroundStatus();
+const globalScope = globalThis as typeof globalThis & {
+	__wpPlaygroundDevToolsContentScriptLoaded?: boolean;
+};
 
-// Listen for requests from the DevTools panel to check again
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-	if (message.type === 'CHECK_PLAYGROUND') {
-		checkForPlayground().then((result) => {
-			sendResponse({
-				hasPlayground: result.hasPlayground,
-				documentRoot: result.documentRoot,
-				url: window.location.href,
+if (!globalScope.__wpPlaygroundDevToolsContentScriptLoaded) {
+	globalScope.__wpPlaygroundDevToolsContentScriptLoaded = true;
+
+	// Check immediately when the script loads
+	reportPlaygroundStatus();
+
+	// Listen for requests from the DevTools panel to check again
+	chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+		if (message.type === 'CHECK_PLAYGROUND') {
+			checkForPlayground().then((result) => {
+				sendResponse({
+					hasPlayground: result.hasPlayground,
+					documentRoot: result.documentRoot,
+					url: window.location.href,
+				});
 			});
-		});
-		return true; // Keep the message channel open for async response
-	}
+			return true; // Keep the message channel open for async response
+		}
 
-	if (message.type === 'EXECUTE_PLAYGROUND_METHOD') {
-		// Execute a method on window.playground and return the result
-		executePlaygroundMethod(message.method, message.args).then(
-			sendResponse
-		);
-		return true;
-	}
-});
+		if (message.type === 'EXECUTE_PLAYGROUND_METHOD') {
+			// Execute a method on window.playground and return the result
+			executePlaygroundMethod(message.method, message.args).then(
+				sendResponse
+			);
+			return true;
+		}
+
+		return false;
+	});
+}
 
 /**
  * Execute a method on window.playground by asking the background script

--- a/packages/playground/devtools-extension/src/panel/panel.module.css
+++ b/packages/playground/devtools-extension/src/panel/panel.module.css
@@ -103,3 +103,70 @@
 		opacity: 1;
 	}
 }
+
+.permissionButton {
+	padding: 10px 20px;
+	font-size: 14px;
+	font-weight: 500;
+	color: #ffffff;
+	background-color: var(--wp-admin-theme-color, #3858e9);
+	border: none;
+	border-radius: 4px;
+	cursor: pointer;
+	transition: background-color 0.15s ease;
+}
+
+.permissionButton:hover:not(:disabled) {
+	background-color: var(--wp-admin-theme-color-darker-10, #2145e6);
+}
+
+.permissionButton:disabled {
+	opacity: 0.6;
+	cursor: not-allowed;
+}
+
+.permissionList {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	width: min(100%, 520px);
+	margin-top: 16px;
+}
+
+.permissionItem {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 16px;
+	padding: 12px;
+	text-align: left;
+	border: 1px solid var(--color-gray-200);
+	border-radius: 4px;
+	background: #ffffff;
+}
+
+.permissionOrigin {
+	font-size: 13px;
+	font-weight: 600;
+	color: var(--color-gray-900);
+	overflow-wrap: anywhere;
+}
+
+.permissionFrame {
+	margin-top: 4px;
+	font-size: 12px;
+	color: var(--color-gray-600);
+}
+
+.permissionError,
+.permissionErrorList {
+	width: min(100%, 520px);
+	margin-top: 16px;
+	font-size: 12px;
+	color: #cc1818;
+}
+
+.permissionErrorList p {
+	margin: 0 0 4px 0;
+	overflow-wrap: anywhere;
+}

--- a/packages/playground/devtools-extension/src/panel/panel.tsx
+++ b/packages/playground/devtools-extension/src/panel/panel.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState, useRef } from 'react';
+import { useCallback, useEffect, useState, useRef } from 'react';
 import { createRoot } from 'react-dom/client';
 import { PlaygroundFileEditor } from '@wp-playground/components';
 import type { AsyncWritableFilesystem } from '@wp-playground/storage';
+import { getOriginPattern, requestPermissionForUrl } from '../permissions';
 import styles from './panel.module.css';
 
 interface PlaygroundFrame {
@@ -10,6 +11,33 @@ interface PlaygroundFrame {
 	url: string;
 	hasPlayground: boolean;
 	documentRoot?: string;
+}
+
+interface FrameAccess {
+	frameId: number;
+	parentFrameId: number;
+	url: string;
+	origin: string;
+	originPattern: string | null;
+	hostname: string;
+	isSupported: boolean;
+	isAllowlisted: boolean;
+	hasPermission: boolean;
+	canRequestPermission: boolean;
+}
+
+interface PermissionOption {
+	url: string;
+	origin: string;
+	originPattern: string;
+	frameIds: number[];
+}
+
+interface InjectionResult {
+	frameId: number;
+	url: string;
+	injected: boolean;
+	error?: string;
 }
 
 /**
@@ -111,6 +139,56 @@ function createPlaygroundFilesystem(
 	return filesystem;
 }
 
+function getPermissionOptions(frameAccess: FrameAccess[]): PermissionOption[] {
+	const options = new Map<string, PermissionOption>();
+
+	for (const frame of frameAccess) {
+		if (
+			!frame.canRequestPermission ||
+			frame.hasPermission ||
+			!frame.originPattern
+		) {
+			continue;
+		}
+
+		const option = options.get(frame.originPattern);
+		if (option) {
+			option.frameIds.push(frame.frameId);
+			continue;
+		}
+
+		options.set(frame.originPattern, {
+			url: frame.url,
+			origin: frame.origin || frame.hostname,
+			originPattern: frame.originPattern,
+			frameIds: [frame.frameId],
+		});
+	}
+
+	return Array.from(options.values()).sort((a, b) => {
+		const aHasMainFrame = a.frameIds.includes(0);
+		const bHasMainFrame = b.frameIds.includes(0);
+		if (aHasMainFrame !== bHasMainFrame) {
+			return aHasMainFrame ? -1 : 1;
+		}
+		return a.origin.localeCompare(b.origin);
+	});
+}
+
+function getFrameLabel(frameIds: number[]): string {
+	if (frameIds.includes(0)) {
+		if (frameIds.length === 1) {
+			return 'Main frame';
+		}
+
+		const subframeCount = frameIds.length - 1;
+		const suffix = subframeCount === 1 ? '' : 's';
+		return `Main frame and ${subframeCount} subframe${suffix}`;
+	}
+
+	return `${frameIds.length} subframe${frameIds.length === 1 ? '' : 's'}`;
+}
+
 function PlaygroundPanel() {
 	const [frames, setFrames] = useState<PlaygroundFrame[]>([]);
 	const [selectedFrame, setSelectedFrame] = useState<PlaygroundFrame | null>(
@@ -119,8 +197,39 @@ function PlaygroundPanel() {
 	const [filesystem, setFilesystem] =
 		useState<AsyncWritableFilesystem | null>(null);
 	const [isConnected, setIsConnected] = useState(false);
+	const [frameAccess, setFrameAccess] = useState<FrameAccess[]>([]);
+	const [requestingPermission, setRequestingPermission] = useState<
+		string | null
+	>(null);
+	const [permissionDenied, setPermissionDenied] = useState<string | null>(
+		null
+	);
+	const [injectionErrors, setInjectionErrors] = useState<InjectionResult[]>(
+		[]
+	);
 	const portRef = useRef<chrome.runtime.Port | null>(null);
 	const refreshIntervalRef = useRef<number | null>(null);
+
+	const handleRequestPermission = useCallback(async (url: string) => {
+		const originPattern = getOriginPattern(url) ?? url;
+
+		setRequestingPermission(originPattern);
+		setPermissionDenied(null);
+		try {
+			const granted = await requestPermissionForUrl(url);
+
+			if (granted && portRef.current) {
+				portRef.current.postMessage({
+					type: 'HOST_PERMISSION_GRANTED',
+					url,
+				});
+			} else if (!granted) {
+				setPermissionDenied(originPattern);
+			}
+		} finally {
+			setRequestingPermission(null);
+		}
+	}, []);
 
 	// Connect to the background script and set up frame detection
 	useEffect(() => {
@@ -136,11 +245,27 @@ function PlaygroundPanel() {
 		port.onMessage.addListener((message) => {
 			if (message.type === 'FRAMES_UPDATED') {
 				setFrames(message.frames);
+				setFrameAccess(message.frameAccess ?? []);
+
+				if (message.injectionResults) {
+					setInjectionErrors(
+						message.injectionResults.filter(
+							(result: InjectionResult) =>
+								!result.injected && result.error
+						)
+					);
+				}
 
 				// Auto-select if there's only one playground frame
-				if (message.frames.length === 1 && !selectedFrame) {
-					setSelectedFrame(message.frames[0]);
+				if (message.frames.length === 1) {
+					setSelectedFrame(
+						(currentFrame) => currentFrame ?? message.frames[0]
+					);
 				}
+			}
+
+			if (message.type === 'INJECTION_COMPLETE') {
+				port.postMessage({ type: 'REFRESH_FRAMES' });
 			}
 		});
 
@@ -188,6 +313,8 @@ function PlaygroundPanel() {
 		setSelectedFrame(frame ?? null);
 	};
 
+	const permissionOptions = getPermissionOptions(frameAccess);
+
 	// If not connected, show error
 	if (!isConnected) {
 		return (
@@ -198,6 +325,70 @@ function PlaygroundPanel() {
 						The connection to the page was lost. Please refresh the
 						DevTools panel.
 					</p>
+				</div>
+			</div>
+		);
+	}
+
+	if (frames.length === 0 && permissionOptions.length > 0) {
+		return (
+			<div className={styles.container}>
+				<div className={styles.message}>
+					<h2>Permission Required</h2>
+					<p>
+						Grant this extension access to the page or frame that
+						contains WordPress Playground.
+					</p>
+					<div className={styles.permissionList}>
+						{permissionOptions.map((option) => {
+							const isRequesting =
+								requestingPermission === option.originPattern;
+							return (
+								<div
+									className={styles.permissionItem}
+									key={option.originPattern}
+								>
+									<div>
+										<div
+											className={styles.permissionOrigin}
+										>
+											{option.origin}
+										</div>
+										<div
+											className={styles.permissionFrame}
+										>
+											{getFrameLabel(option.frameIds)}
+										</div>
+									</div>
+									<button
+										className={styles.permissionButton}
+										onClick={() =>
+											handleRequestPermission(option.url)
+										}
+										disabled={isRequesting}
+									>
+										{isRequesting
+											? 'Requesting...'
+											: 'Grant Permission'}
+									</button>
+								</div>
+							);
+						})}
+					</div>
+					{permissionDenied && (
+						<p className={styles.permissionError}>
+							Permission was not granted for {permissionDenied}.
+						</p>
+					)}
+					{injectionErrors.length > 0 && (
+						<div className={styles.permissionErrorList}>
+							{injectionErrors.map((result) => (
+								<p key={`${result.frameId}:${result.url}`}>
+									Frame {result.frameId}: {result.error}
+								</p>
+							))}
+						</div>
+					)}
 				</div>
 			</div>
 		);
@@ -220,6 +411,15 @@ function PlaygroundPanel() {
 					<p className={styles.hint}>
 						Scanning for playground instances...
 					</p>
+					{injectionErrors.length > 0 && (
+						<div className={styles.permissionErrorList}>
+							{injectionErrors.map((result) => (
+								<p key={`${result.frameId}:${result.url}`}>
+									Frame {result.frameId}: {result.error}
+								</p>
+							))}
+						</div>
+					)}
 				</div>
 			</div>
 		);

--- a/packages/playground/devtools-extension/src/permissions.spec.ts
+++ b/packages/playground/devtools-extension/src/permissions.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+	getHostname,
+	getOrigin,
+	getOriginPattern,
+	isAllowlistedUrl,
+	isSupportedUrl,
+} from './permissions';
+
+describe('DevTools extension permissions', () => {
+	it('creates Chrome host permission patterns without ports', () => {
+		expect(
+			getOriginPattern('http://arbitrary-playground.test:8888/page')
+		).toBe('http://arbitrary-playground.test/*');
+		expect(
+			getOriginPattern('https://arbitrary-playground.test:9443/page')
+		).toBe('https://arbitrary-playground.test/*');
+	});
+
+	it('does not create host permission patterns for unsupported schemes', () => {
+		expect(getOriginPattern('chrome://extensions')).toBeNull();
+		expect(getOriginPattern('file:///tmp/playground.html')).toBeNull();
+	});
+
+	it('keeps origin labels and hostnames useful for UI display', () => {
+		const url = 'http://arbitrary-playground.test:8888/page';
+
+		expect(getOrigin(url)).toBe('http://arbitrary-playground.test:8888');
+		expect(getHostname(url)).toBe('arbitrary-playground.test');
+	});
+
+	it('keeps the built-in allowlist exact', () => {
+		expect(isAllowlistedUrl('https://wordpress.org/playground')).toBe(true);
+		expect(isAllowlistedUrl('https://make.wordpress.org/core')).toBe(false);
+		expect(isAllowlistedUrl('https://playground.wordpress.net/')).toBe(
+			true
+		);
+	});
+
+	it('only supports web page URLs for optional host grants', () => {
+		expect(isSupportedUrl('http://arbitrary-playground.test')).toBe(true);
+		expect(isSupportedUrl('https://arbitrary-playground.test')).toBe(true);
+		expect(isSupportedUrl('chrome://extensions')).toBe(false);
+	});
+});

--- a/packages/playground/devtools-extension/src/permissions.ts
+++ b/packages/playground/devtools-extension/src/permissions.ts
@@ -1,0 +1,85 @@
+const ALLOWLISTED_HOSTS = [
+	'playground.wordpress.net',
+	'developer.wordpress.org',
+	'developer.woocommerce.com',
+	'developer.wordpress.com',
+	'wordpress.org',
+	'localhost',
+	'127.0.0.1',
+];
+
+export async function hasPermissionForUrl(url: string): Promise<boolean> {
+	const originPattern = getOriginPattern(url);
+	if (!originPattern) {
+		return false;
+	}
+
+	try {
+		return await chrome.permissions.contains({
+			origins: [originPattern],
+		});
+	} catch {
+		return false;
+	}
+}
+
+export async function requestPermissionForUrl(url: string): Promise<boolean> {
+	const originPattern = getOriginPattern(url);
+	if (!originPattern) {
+		return false;
+	}
+
+	try {
+		return await chrome.permissions.request({
+			origins: [originPattern],
+		});
+	} catch {
+		return false;
+	}
+}
+
+export function isAllowlistedUrl(url: string): boolean {
+	const hostname = getHostname(url);
+	return ALLOWLISTED_HOSTS.includes(hostname);
+}
+
+export function getHostname(url: string): string {
+	try {
+		return new URL(url).hostname;
+	} catch {
+		return '';
+	}
+}
+
+export function getOrigin(url: string): string {
+	try {
+		return new URL(url).origin;
+	} catch {
+		return '';
+	}
+}
+
+export function getOriginPattern(url: string): string | null {
+	try {
+		const urlObject = new URL(url);
+		if (!isSupportedProtocol(urlObject.protocol)) {
+			return null;
+		}
+
+		return `${urlObject.protocol}//${urlObject.hostname}/*`;
+	} catch {
+		return null;
+	}
+}
+
+export function isSupportedUrl(url: string): boolean {
+	try {
+		return isSupportedProtocol(new URL(url).protocol);
+	} catch {
+		return false;
+	}
+}
+
+function isSupportedProtocol(protocol: string): boolean {
+	return protocol === 'http:' || protocol === 'https:';
+}

--- a/packages/playground/devtools-extension/tsconfig.spec.json
+++ b/packages/playground/devtools-extension/tsconfig.spec.json
@@ -1,0 +1,22 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"types": [
+			"vitest/globals",
+			"vitest/importMeta",
+			"vite/client",
+			"node",
+			"chrome"
+		]
+	},
+	"include": [
+		"vite.config.ts",
+		"vitest.config.ts",
+		"src/**/*.test.ts",
+		"src/**/*.spec.ts",
+		"src/**/*.test.tsx",
+		"src/**/*.spec.tsx",
+		"src/**/*.d.ts"
+	]
+}

--- a/packages/playground/devtools-extension/vitest.config.ts
+++ b/packages/playground/devtools-extension/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
+
+export default defineConfig({
+	root: __dirname,
+	plugins: [
+		viteTsConfigPaths({
+			root: '../../../',
+		}),
+	],
+	test: {
+		include: ['src/**/*.spec.ts', 'src/**/*.test.ts'],
+	},
+});


### PR DESCRIPTION
## What it does

Narrows the DevTools extension's default host access to known Playground and WordPress domains while keeping arbitrary Playground integrations debuggable through explicit per-origin grants.

Non-allowlisted pages now show grant options for the inspected page and its frames. After a grant, the extension registers and injects the content script for that origin so reloads and later navigations continue to work.

Refs #44.

## Rationale

The extension should avoid install-time access to every site, but Playground can be embedded on custom domains. A fixed allowlist alone would break that debugging workflow. This keeps first-party domains automatic and moves arbitrary-site access to an intentional DevTools-panel action.

## Implementation

- Keeps default `host_permissions` and static `content_scripts` limited to known Playground/WordPress hosts.
- Uses `optional_host_permissions` for `http://*/*` and `https://*/*`, not default `<all_urls>` access.
- Tracks frame access in the background worker using `chrome.webNavigation.getAllFrames()` and `chrome.permissions.contains()`.
- Registers dynamic content scripts with `chrome.scripting.registerContentScripts()` after a host grant, then injects the current matching frames.
- Re-scans frames after permission grants and navigation, and unregisters dynamic scripts when permissions are removed.
- Builds permission request patterns without ports, so local/custom domains like `http://example.test:8888` request `http://example.test/*`.
- Guards the content script against duplicate listeners when static, dynamic, and programmatic injection overlap.
- Adds focused Vitest coverage for permission pattern and allowlist behavior.

## Testing instructions

```bash
NX_DAEMON=false npx nx run playground-devtools-extension:lint --skip-nx-cache
NX_DAEMON=false npx nx run playground-devtools-extension:typecheck --skip-nx-cache
NX_DAEMON=false npx nx run playground-devtools-extension:test --skip-nx-cache
npx vitest run packages/playground/devtools-extension/src/permissions.spec.ts
cd packages/playground/devtools-extension && npx vite build
git diff --check origin/trunk...HEAD
git diff --check
```