### PR TITLE
Add SMTP sink runtime helper

### DIFF
--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -460,6 +460,15 @@ RUN /root/replace.sh 's/PHPAPI int php_exec(.+)$/PHPAPI extern int php_exec\1; i
 RUN /root/replace.sh 's/#define VCWD_POPEN.+/#define VCWD_POPEN(command, type) wasm_popen(command,type)/g' /root/php-src/Zend/zend_virtual_cwd.h
 RUN echo 'extern FILE *wasm_popen(const char *cmd, const char *mode);' >> /root/php-src/Zend/zend_virtual_cwd.h
 
+# Patch mail.c for Emscripten compatibility:
+# 1. Use VCWD_POPEN (routed through wasm_popen) instead of raw popen(),
+#    so that PHP's mail() function goes through our JS spawn handler.
+# 2. Use wasm_pclose() instead of pclose() so we wait for the spawned
+#    process to finish and get a correct exit code. Libc's pclose() doesn't
+#    work with FILE handles created by wasm_popen (fdopen).
+RUN sed -i '1i #include <stdio.h>\nextern int wasm_pclose(FILE *fp);' /root/php-src/ext/standard/mail.c
+RUN perl -pi.bak -e 's/\bpopen\s*\(\s*sendmail_cmd\s*,/VCWD_POPEN(sendmail_cmd,/g; s/\bpclose\s*\(\s*sendmail\s*\)/wasm_pclose(sendmail)/g' /root/php-src/ext/standard/mail.c
+
 # Provide a custom implementation of the shutdown() function.
 RUN perl -pi.bak -e $'s/(\s+)shutdown\(/$1 wasm_shutdown(/g' /root/php-src/sapi/cli/php_cli_server.c
 RUN perl -pi.bak -e $'s/(\s+)closesocket\(/$1 wasm_close(/g' /root/php-src/sapi/cli/php_cli_server.c
@@ -711,6 +720,7 @@ RUN export ASYNCIFY_IMPORTS=$'[\n\
 "php_init_config",\
 "zend_register_constant",\
 "zend_register_ini_entries_ex",\
+"php_mail",\
 "php_module_startup",\
 "wasm_sapi_module_startup",\
 "__fseeko_unlocked",\
@@ -1675,6 +1685,7 @@ RUN export ASYNCIFY_IMPORTS=$'[\n\
 "wasm_php_exec",\
 "wasm_php_stream_flush",\
 "wasm_php_stream_read",\
+"wasm_pclose",\
 "wasm_popen",\
 "wasm_read",\
 "wasm_sapi_handle_request",\
@@ -2039,6 +2050,7 @@ RUN export ASYNCIFY_IMPORTS=$'[\n\
 "zif_passthru",\
 "zif_phar_file_get_contents",\
 "zif_phar_fopen",\
+"zif_mail",\
 "zif_popen",\
 "zif_post_message_to_js",\
 "zif_preg_replace_callback",\
@@ -2367,7 +2379,7 @@ RUN set -euxo pipefail; \
 	ZEND_SIDE_MODULE_EXPORT_SOURCE=""; \
 	if [ "$WITH_JSPI" = "yes" ]; then \
 		# Both imports and exports are required for inter-module communication with wrapped methods, e.g., wasm_recv.
-		export ASYNCIFY_FLAGS=" -s ASYNCIFY=2 -sSUPPORT_LONGJMP=wasm -fwasm-exceptions -sJSPI_IMPORTS=js_open_process,js_fd_read,js_waitpid,js_process_status,js_create_input_device,wasm_setsockopt,wasm_shutdown,wasm_close,wasm_recv,wasm_connect,__syscall_fcntl64,js_flock,js_release_file_locks,js_waitpid -sJSPI_EXPORTS=php_wasm_init,wasm_sleep,wasm_read,emscripten_sleep,wasm_sapi_handle_request,wasm_sapi_request_shutdown,wasm_poll_socket,wrap_select,__wrap_select,select,php_pollfd_for,fflush,wasm_popen,wasm_read,wasm_php_exec,run_cli,wasm_recv,wasm_connect,__wasm_call_ctors,__errno_location,__funcs_on_exit -s EXPORTED_RUNTIME_METHODS=HEAPU32,HEAPU8,ccall,PROXYFS,wasmExports "; \
+		export ASYNCIFY_FLAGS=" -s ASYNCIFY=2 -sSUPPORT_LONGJMP=wasm -fwasm-exceptions -sJSPI_IMPORTS=js_open_process,js_fd_read,js_waitpid,js_process_status,js_create_input_device,wasm_setsockopt,wasm_shutdown,wasm_close,wasm_recv,wasm_connect,__syscall_fcntl64,js_flock,js_release_file_locks,js_waitpid -sJSPI_EXPORTS=php_wasm_init,wasm_sleep,wasm_read,emscripten_sleep,wasm_sapi_handle_request,wasm_sapi_request_shutdown,wasm_poll_socket,wrap_select,__wrap_select,select,php_pollfd_for,fflush,wasm_popen,wasm_pclose,wasm_read,wasm_php_exec,run_cli,wasm_recv,wasm_connect,__wasm_call_ctors,__errno_location,__funcs_on_exit -s EXPORTED_RUNTIME_METHODS=HEAPU32,HEAPU8,ccall,PROXYFS,wasmExports "; \
 		echo '#define PLAYGROUND_JSPI 1' > /root/php_wasm_asyncify.h; \
 		ZEND_SIDE_MODULE_EXPORT_SOURCE="/root/zend-side-module-exports.c"; \
 	else \

--- a/packages/php-wasm/compile/php/php_wasm.c
+++ b/packages/php-wasm/compile/php/php_wasm.c
@@ -432,6 +432,10 @@ extern int __wasi_syscall_ret(__wasi_errno_t code);
 // Exit code of the last exited child process call.
 int wasm_pclose_ret = -1;
 
+// PID of the last process spawned by wasm_popen("w").
+// Used by wasm_pclose to wait for the process to finish.
+static int wasm_popen_last_pid = -1;
+
 /**
  * Passes a message to the JavaScript module and writes the response
  * data, if any, to the response_buffer pointer.
@@ -517,7 +521,7 @@ EMSCRIPTEN_KEEPALIVE FILE *wasm_popen(const char *cmd, const char *mode)
 			return 0;
 		}
 
-		fp = fdopen(stdin_pipe[1], "w");  // or "w", depending on direction
+		fp = fdopen(stdin_pipe[1], "w");
 		if (!fp) {
 			php_error_docref(NULL, E_WARNING, "unable to create pipe %s", strerror(errno));
 			errno = EINVAL;
@@ -546,8 +550,7 @@ EMSCRIPTEN_KEEPALIVE FILE *wasm_popen(const char *cmd, const char *mode)
 		descv[1] = stdout;
 		descv[2] = stderr;
 
-		// the wasm way {{{
-		js_open_process(
+		wasm_popen_last_pid = js_open_process(
 			cmd,
 			NULL,
 			0,
@@ -558,7 +561,6 @@ EMSCRIPTEN_KEEPALIVE FILE *wasm_popen(const char *cmd, const char *mode)
 			0,
 			0
 		);
-		// }}}
 
 		efree(stdin);
 		efree(stdout);
@@ -574,6 +576,32 @@ EMSCRIPTEN_KEEPALIVE FILE *wasm_popen(const char *cmd, const char *mode)
 	}
 
 	return fp;
+}
+
+/**
+ * Close a FILE* created by wasm_popen and wait for the spawned process
+ * to exit. Returns the process exit code, or -1 on error.
+ *
+ * TODO: wasm_popen_last_pid and wasm_pclose_ret are single globals, so
+ * concurrent writable popen() calls will clobber each other's PID and exit
+ * code. Safe today because mail() is the only caller and it does a strict
+ * open-write-close sequence, but a proper fix would stash both in a table
+ * keyed by fd.
+ */
+extern int js_waitpid(int pid, int *exitcode);
+
+EMSCRIPTEN_KEEPALIVE int wasm_pclose(FILE *fp)
+{
+	int pid = wasm_popen_last_pid;
+	fclose(fp);
+	if (pid < 0) {
+		return -1;
+	}
+	int wstatus = 0;
+	js_waitpid(pid, &wstatus);
+	wasm_pclose_ret = wstatus;
+	FG(pclose_ret) = wstatus;
+	return wstatus;
 }
 
 /**

--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -170,7 +170,8 @@
 					"php-imagick.spec.ts",
 					"php-soap.spec.ts",
 					"php-image-extensions.spec.ts",
-					"php-fsockopen.spec.ts"
+					"php-fsockopen.spec.ts",
+					"php-smtp.spec.ts"
 				]
 			}
 		},
@@ -184,7 +185,8 @@
 					"php-imagick.spec.ts",
 					"php-soap.spec.ts",
 					"php-image-extensions.spec.ts",
-					"php-fsockopen.spec.ts"
+					"php-fsockopen.spec.ts",
+					"php-smtp.spec.ts"
 				]
 			}
 		},

--- a/packages/php-wasm/node/src/lib/load-runtime.ts
+++ b/packages/php-wasm/node/src/lib/load-runtime.ts
@@ -10,6 +10,7 @@ import {
 	createLegacyPhpIniPreRunStep,
 	isLegacyPHPVersion,
 	ProcessIdAllocator,
+	withSMTPSink,
 } from '@php-wasm/universal';
 import type { WasmUserSpaceAPI, WasmUserSpaceContext } from './wasm-user-space';
 import { bindUserSpace } from './wasm-user-space';
@@ -23,7 +24,12 @@ import {
 	type PHPExtension,
 	type XdebugOptions,
 } from './extensions/load-extensions';
-import { dirname, joinPaths, toPosixPath } from '@php-wasm/util';
+import {
+	dirname,
+	joinPaths,
+	toPosixPath,
+	type CaughtMessage,
+} from '@php-wasm/util';
 import { platform } from 'os';
 import { jspi } from 'wasm-feature-detect';
 
@@ -53,6 +59,10 @@ export interface PHPLoaderOptions {
 	 * @deprecated Use `extensions: ['memcached']` instead.
 	 */
 	withMemcached?: boolean;
+	withSMTPSink?: {
+		port: number;
+		onEmail: (message: CaughtMessage) => void;
+	};
 }
 
 export type PHPLoaderOptionsForNode = PHPLoaderOptions & {
@@ -376,6 +386,12 @@ export async function loadNodeRuntime(
 	}
 
 	emscriptenOptions = await withNetworking(emscriptenOptions);
+	if (options.withSMTPSink) {
+		emscriptenOptions = withSMTPSink(
+			options.withSMTPSink,
+			emscriptenOptions
+		);
+	}
 
 	const phpLoaderModule = await getPHPLoaderModule(phpVersion);
 

--- a/packages/php-wasm/node/src/test/php-smtp.spec.ts
+++ b/packages/php-wasm/node/src/test/php-smtp.spec.ts
@@ -1,0 +1,132 @@
+import { PHP, setPhpIniEntries } from '@php-wasm/universal';
+import type { CaughtMessage } from '@php-wasm/util';
+import { loadNodeRuntime } from '../lib';
+
+const phpVersions = ['8.4'];
+// TODO re-enable testing on all versions before merging
+// 'PHP' in process.env
+// 	? [process.env['PHP']! as SupportedPHPVersion]
+// 	: SupportedPHPVersions;
+
+describe.each(phpVersions)('PHP %s - SMTP sink', (phpVersion) => {
+	let php: PHP;
+	let emails: CaughtMessage[];
+
+	beforeEach(async () => {
+		emails = [];
+		php = new PHP(
+			await loadNodeRuntime(phpVersion as any, {
+				withSMTPSink: {
+					port: 25,
+					onEmail: (m: CaughtMessage) => emails.push(m),
+				},
+			})
+		);
+		await setPhpIniEntries(php, {
+			disable_functions: '',
+			allow_url_fopen: 1,
+		});
+	}, 30_000);
+
+	afterEach(() => {
+		php?.exit();
+	});
+
+	it('captures an email piped via proc_open to sendmail', async () => {
+		const result = await php.run({
+			code: `<?php
+				error_reporting(E_ALL);
+				$email = "From: sender@test.com\r\nTo: recipient@test.com\r\nSubject: Hello from PHP\r\n\r\nThis is the body.";
+				$proc = proc_open(
+					'/usr/sbin/sendmail -t -i',
+					[['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']],
+					$pipes
+				);
+				if (!is_resource($proc)) {
+					echo 'PROC_OPEN_FAILED';
+					exit;
+				}
+				fwrite($pipes[0], $email);
+				fclose($pipes[0]);
+				$exit = proc_close($proc);
+				echo $exit === 0 ? 'SENT' : 'EXIT_' . $exit;
+			`,
+		});
+
+		expect(result.text).toBe('SENT');
+		expect(emails).toHaveLength(1);
+		expect(emails[0].from).toContain('sender@test.com');
+		expect(emails[0].to).toContain('recipient@test.com');
+		expect(emails[0].subject).toBe('Hello from PHP');
+		expect(emails[0].text?.trim()).toBe('This is the body.');
+	});
+
+	it('captures an email sent via fsockopen SMTP', async () => {
+		const result = await php.run({
+			code: `<?php
+				error_reporting(E_ALL);
+
+				function smtp_read_reply($fp) {
+					$lines = '';
+					while (($line = fgets($fp)) !== false) {
+						$lines .= $line;
+						if (preg_match('/^\\d{3} /', $line)) break;
+					}
+					return $lines;
+				}
+
+				$smtp = fsockopen('localhost', 25, $errno, $errstr, 5);
+				if (!$smtp) { echo "CONNECT_FAILED: $errstr ($errno)"; exit; }
+
+				smtp_read_reply($smtp);
+				fwrite($smtp, "EHLO localhost\\r\\n");
+				smtp_read_reply($smtp);
+				fwrite($smtp, "MAIL FROM:<sender@test.com>\\r\\n");
+				smtp_read_reply($smtp);
+				fwrite($smtp, "RCPT TO:<recipient@test.com>\\r\\n");
+				smtp_read_reply($smtp);
+				fwrite($smtp, "DATA\\r\\n");
+				smtp_read_reply($smtp);
+				fwrite($smtp, "From: sender@test.com\\r\\n");
+				fwrite($smtp, "To: recipient@test.com\\r\\n");
+				fwrite($smtp, "Subject: Hello via SMTP\\r\\n");
+				fwrite($smtp, "\\r\\n");
+				fwrite($smtp, "This is the body.\\r\\n");
+				fwrite($smtp, ".\\r\\n");
+				smtp_read_reply($smtp);
+				fwrite($smtp, "QUIT\\r\\n");
+				fclose($smtp);
+				echo 'SENT';
+			`,
+		});
+
+		expect(result.text).toBe('SENT');
+		expect(emails).toHaveLength(1);
+		expect(emails[0].from).toContain('sender@test.com');
+		expect(emails[0].to).toContain('recipient@test.com');
+		expect(emails[0].subject).toBe('Hello via SMTP');
+		expect(emails[0].text?.trim()).toBe('This is the body.');
+	});
+
+	it.skip('captures an email sent via mail()', async () => {
+		const result = await php.run({
+			code: `<?php
+				error_reporting(E_ALL);
+				$result = mail(
+					'recipient@test.com',
+					'Hello from PHP',
+					'This is the body.',
+					'From: sender@test.com'
+				);
+				echo $result ? 'SENT' : 'FAILED';
+			`,
+		});
+
+		expect(result.text).toBe('SENT');
+		expect(emails).toHaveLength(1);
+		expect(emails[0].from).toContain('sender@test.com');
+		expect(emails[0].to).toContain('recipient@test.com');
+		expect(emails[0].subject).toBe('Hello from PHP');
+		expect(emails[0].text?.trim()).toBe('This is the body.');
+	});
+});

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -123,6 +123,8 @@ export {
 export { isExitCode } from './is-exit-code';
 export { proxyFileSystem, isPathToSharedFS } from './proxy-file-system';
 export { sandboxedSpawnHandlerFactory } from './sandboxed-spawn-handler-factory';
+export { withSMTPSink } from './with-smtp-sink';
+export type { WithSmtpSinkOptions } from './with-smtp-sink';
 
 export * from './api';
 export type { WithAPIState as WithIsReady } from './api';

--- a/packages/php-wasm/universal/src/lib/with-smtp-sink.ts
+++ b/packages/php-wasm/universal/src/lib/with-smtp-sink.ts
@@ -1,0 +1,75 @@
+import type { EmscriptenOptions } from './load-php-runtime';
+import {
+	SmtpSinkWebSocket,
+	createSendmailSpawnHandler,
+	type CaughtMessage,
+} from '@php-wasm/util';
+
+export type WithSmtpSinkOptions = {
+	port: number;
+	onEmail: (message: CaughtMessage) => void;
+};
+
+/**
+ * Captures outbound email from PHP via two interception points:
+ *   1. `spawnProcess` - catches `mail()` calls that shell out to sendmail.
+ *   2. `websocket.decorator` - catches TCP connections to the given SMTP
+ *      port and routes them through an in-process SmtpSink.
+ *
+ * Merges into the provided `emscriptenOptions`, chaining the websocket
+ * decorator and using any existing `spawnProcess` as a fallback for
+ * non-sendmail commands.
+ *
+ * Works in both Web and Node runtimes since both hooks are part of the
+ * shared EmscriptenOptions surface.
+ */
+export function withSMTPSink(
+	{ port, onEmail }: WithSmtpSinkOptions,
+	emscriptenOptions: EmscriptenOptions = {}
+): EmscriptenOptions {
+	// TODO: Provide a way for the Playground website to read received messages.
+	const prevWs = emscriptenOptions['websocket'] || {};
+	const prevDecorator = prevWs.decorator as ((Base: any) => any) | undefined;
+
+	const smtpDecorator = (BaseWebSocketConstructor: any) => {
+		return class SMTPDecoratedWebSocket extends BaseWebSocketConstructor {
+			constructor(url: string, wsOptions?: any) {
+				let targetPort = -1;
+				try {
+					const u = new URL(url);
+					targetPort = parseInt(
+						u.searchParams.get('port') || '-1',
+						10
+					);
+				} catch {
+					// Ignore URL parse errors
+				}
+
+				if (targetPort === port) {
+					// Returning an object from a constructor
+					// bypasses `this`, avoiding a super() call
+					// that would open a real connection to the
+					// SMTP port.
+					return new SmtpSinkWebSocket(url, onEmail) as any;
+				}
+
+				super(url, wsOptions);
+			}
+		};
+	};
+
+	return {
+		...emscriptenOptions,
+		spawnProcess: createSendmailSpawnHandler(
+			onEmail,
+			emscriptenOptions['spawnProcess']
+		),
+		websocket: {
+			...prevWs,
+			decorator: (Base: any) => {
+				const AfterPrev = prevDecorator ? prevDecorator(Base) : Base;
+				return smtpDecorator(AfterPrev);
+			},
+		},
+	};
+}

--- a/packages/php-wasm/util/src/lib/create-sendmail-handler.ts
+++ b/packages/php-wasm/util/src/lib/create-sendmail-handler.ts
@@ -1,0 +1,127 @@
+import { createSpawnHandler } from './create-spawn-handler';
+import { parseMessage } from './smtp';
+import type { CaughtMessage } from './smtp';
+
+/**
+ * Intercepts PHP's mail() function and routes the outgoing message to
+ * `onEmail`.
+ *
+ * PHP's mail() pipes a fully-formed message to the program in php.ini's
+ * `sendmail_path`, which defaults to `/usr/sbin/sendmail -t -i`. The `-t`
+ * means a real sendmail would read recipients from the To/Cc/Bcc headers,
+ * and this handler relies on that - it always extracts recipients from the
+ * headers rather than from command-line arguments.
+ *
+ * Any command whose binary basename is `sendmail` is matched. Other
+ * commands are forwarded to `fallbackSpawnHandler` if provided, otherwise
+ * they throw.
+ */
+const DEFAULT_MAX_SIZE = 10 * 1024 * 1024; // 10 MB, same as SmtpSink
+
+export function createSendmailSpawnHandler(
+	onEmail: (message: CaughtMessage) => void,
+	fallbackSpawnHandler?: (
+		command: any,
+		argsArray?: any,
+		options?: any
+	) => any,
+	{ maxSize = DEFAULT_MAX_SIZE }: { maxSize?: number } = {}
+) {
+	const sendmailHandler = createSpawnHandler(
+		async function (command, processApi) {
+			let envelopeSender = '';
+			for (let i = 1; i < command.length; i++) {
+				if (command[i] === '-f' && i + 1 < command.length) {
+					envelopeSender = command[++i];
+				} else if (
+					command[i].startsWith('-f') &&
+					command[i].length > 2
+				) {
+					envelopeSender = command[i].slice(2);
+				}
+			}
+
+			const chunks: Uint8Array[] = [];
+			let totalLen = 0;
+			let overflow = false;
+			const stdinDone = new Promise<void>((resolve) => {
+				processApi.childProcess.stdin.on('finish', resolve);
+			});
+			processApi.on('stdin', (data: Uint8Array) => {
+				if (overflow) return;
+				totalLen += data.length;
+				if (totalLen > maxSize) {
+					overflow = true;
+					chunks.length = 0;
+					return;
+				}
+				chunks.push(data.slice());
+			});
+
+			await stdinDone;
+
+			if (overflow) {
+				processApi.stderr(
+					`sendmail: message exceeds maximum size (${maxSize} bytes)\n`
+				);
+				processApi.exit(1);
+				return;
+			}
+
+			const all = new Uint8Array(totalLen);
+			let offset = 0;
+			for (const c of chunks) {
+				all.set(c, offset);
+				offset += c.length;
+			}
+			const rawText = new TextDecoder().decode(all);
+
+			if (!rawText.trim()) {
+				processApi.exit(0);
+				return;
+			}
+
+			// Normalize line endings to CRLF for the email parsers
+			const raw = rawText.replace(/\r?\n/g, '\r\n');
+
+			const parsed = parseMessage(raw, envelopeSender, []);
+
+			const message: CaughtMessage = {
+				receivedAt: new Date().toISOString(),
+				from: parsed.from,
+				to: parsed.to,
+				subject: parsed.subject,
+				headers: parsed.headers,
+				text: parsed.text,
+				raw,
+				rawSize: raw.length,
+			};
+
+			onEmail(message);
+
+			processApi.exit(0);
+		}
+	);
+
+	return function (
+		command: string | string[],
+		argsArray: string[] = [],
+		options: any = {}
+	) {
+		const cmdStr = Array.isArray(command)
+			? command[0]
+			: typeof command === 'string'
+				? command.split(/\s+/)[0]
+				: '';
+		const bin = cmdStr.split('/').pop() || '';
+		if (bin !== 'sendmail') {
+			if (fallbackSpawnHandler) {
+				return fallbackSpawnHandler(command, argsArray, options);
+			}
+			throw new Error(
+				`createSendmailSpawnHandler: not a sendmail command: ${cmdStr}`
+			);
+		}
+		return sendmailHandler(command, argsArray, options);
+	};
+}

--- a/packages/php-wasm/util/src/lib/create-sendmail-handler.ts
+++ b/packages/php-wasm/util/src/lib/create-sendmail-handler.ts
@@ -94,7 +94,7 @@ export function createSendmailSpawnHandler(
 				headers: parsed.headers,
 				text: parsed.text,
 				raw,
-				rawSize: raw.length,
+				rawSize: new TextEncoder().encode(raw).byteLength,
 			};
 
 			onEmail(message);

--- a/packages/php-wasm/util/src/lib/index.ts
+++ b/packages/php-wasm/util/src/lib/index.ts
@@ -18,6 +18,10 @@ export { splitShellCommand } from './split-shell-command';
 export { WritablePolyfill, type WritableOptions } from './writable-polyfill';
 export { EventEmitterPolyfill } from './event-emitter-polyfill';
 export * from './php-vars';
+export * from './smtp';
+export * from './smtp-sink-websocket';
+export * from './create-sendmail-handler';
+export * from './websocket-shim';
 
 export * from './sprintf';
 

--- a/packages/php-wasm/util/src/lib/smtp-sink-websocket.ts
+++ b/packages/php-wasm/util/src/lib/smtp-sink-websocket.ts
@@ -1,0 +1,75 @@
+import { WebSocketShim } from './websocket-shim';
+import { SmtpSink, makeLoopbackPair, type CaughtMessage } from './smtp';
+
+/**
+ * A WebSocket-shaped class that pipes outbound bytes through an in-process
+ * SmtpSink instead of opening a real network connection. Used to intercept
+ * Emscripten's SMTP-bound TCP traffic.
+ */
+export class SmtpSinkWebSocket extends WebSocketShim {
+	private writer: WritableStreamDefaultWriter<Uint8Array>;
+	private pendingWrites: Uint8Array[] | null = [];
+
+	constructor(url: string, onEmail: (message: CaughtMessage) => void) {
+		super(url);
+
+		const [client, server] = makeLoopbackPair();
+		void new SmtpSink(server, onEmail).start();
+		this.writer = client.writable.getWriter();
+
+		this.emitOpen();
+		client.readable
+			.pipeTo(
+				new WritableStream({
+					write: (chunk) => this.emitMessage(chunk),
+				})
+			)
+			.finally(() => {
+				if (this.readyState !== this.CLOSED) this.emitClose();
+			});
+	}
+
+	override emitOpen() {
+		super.emitOpen();
+		const buffered = this.pendingWrites;
+		this.pendingWrites = null;
+		if (buffered) {
+			for (const bytes of buffered) {
+				this.writeToStream(bytes);
+			}
+		}
+	}
+
+	override send(data: ArrayBuffer | Uint8Array | string) {
+		const bytes =
+			typeof data === 'string'
+				? new TextEncoder().encode(data)
+				: data instanceof ArrayBuffer
+					? new Uint8Array(data)
+					: data;
+
+		if (this.readyState === this.CONNECTING) {
+			this.pendingWrites!.push(bytes);
+			return;
+		}
+		if (this.readyState !== this.OPEN) {
+			this.emitError(
+				new Error(
+					`SmtpSinkWebSocket: send() called in state ${this.readyState}`
+				)
+			);
+			return;
+		}
+		this.writeToStream(bytes);
+	}
+
+	private writeToStream(bytes: Uint8Array) {
+		void this.writer.write(bytes);
+	}
+
+	override close() {
+		if (this.readyState >= this.CLOSING) return;
+		this.readyState = this.CLOSING;
+		void this.writer.close();
+	}
+}

--- a/packages/php-wasm/util/src/lib/smtp.test.ts
+++ b/packages/php-wasm/util/src/lib/smtp.test.ts
@@ -1,0 +1,981 @@
+import { describe, it, expect } from 'vitest';
+import {
+	SmtpSink,
+	makeLoopbackPair,
+	parseMessage,
+	type CaughtMessage,
+	type SmtpSinkOptions,
+} from './smtp';
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+/**
+ * Spins up a fake SMTP server (the "sink") connected to an in-memory
+ * client via a loopback byte stream. Returns helpers that let tests
+ * act as an SMTP client: send commands, read responses, and inspect
+ * captured emails.
+ *
+ * - `messages` collects every email the sink accepted.
+ * - The sink starts listening immediately.
+ */
+function createClient(opts?: SmtpSinkOptions) {
+	const [duplexClient, duplexServer] = makeLoopbackPair();
+	const messages: CaughtMessage[] = [];
+	const sink = new SmtpSink(
+		duplexServer,
+		(m: CaughtMessage) => messages.push(m),
+		opts
+	);
+	void sink.start();
+	const writer = duplexClient.writable.getWriter();
+	const reader = duplexClient.readable.getReader();
+
+	/** Read the next chunk the server sent (e.g. a response line). */
+	async function read(): Promise<string> {
+		const { value } = await reader.read();
+		return value ? dec.decode(value) : '';
+	}
+
+	/** Send raw bytes to the server (no CRLF added). */
+	async function write(s: string) {
+		await writer.write(enc.encode(s));
+	}
+
+	return {
+		read,
+		write,
+		messages,
+		sink,
+	};
+}
+
+/** Run a full EHLO handshake, consuming multi-line responses. */
+async function ehlo(
+	client: ReturnType<typeof createClient>,
+	hostname = 'localhost'
+): Promise<string[]> {
+	await client.write(`EHLO ${hostname}\r\n`);
+	const lines: string[] = [];
+	for (;;) {
+		const resp = await client.read();
+		lines.push(resp);
+		if (/^250 /m.test(resp)) break;
+		if (!/^250-/m.test(resp))
+			throw new Error(`Unexpected EHLO response: ${resp}`);
+	}
+	return lines;
+}
+
+describe('SmtpSink - happy path', () => {
+	it('captures an email through a full SMTP transaction', async () => {
+		// Walks the canonical SMTP transaction from RFC 5321 section 3.3:
+		// 220 greeting -> HELO -> MAIL FROM -> RCPT TO -> DATA (354) ->
+		// body terminated by ".<CRLF>" (250 queued) -> QUIT (221).
+		const client = createClient();
+		const greeting = await client.read();
+		expect(greeting).toMatch(/^220 /);
+
+		await client.write('HELO localhost\r\n');
+		let helo = await client.read();
+		while (/^250-/.test(helo)) helo = await client.read();
+		expect(helo).toMatch(/^250 /);
+
+		await client.write('MAIL FROM:<test@localhost>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+
+		await client.write('RCPT TO:<test2@localhost>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+
+		await client.write('DATA\r\n');
+		expect(await client.read()).toMatch(/^354 /);
+
+		await client.write('Subject: Test Email\r\n');
+		await client.write('From: test@localhost\r\n');
+		await client.write('To: test2@localhost\r\n');
+		await client.write('\r\n');
+		await client.write('This is the email body content.\r\n');
+		await client.write('.\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+
+		await client.write('QUIT\r\n');
+		expect(await client.read()).toMatch(/^221 /);
+
+		expect(client.messages).toHaveLength(1);
+		const msg = client.messages[0];
+		expect(msg.subject).toBe('Test Email');
+		expect(msg.from).toContain('test@localhost');
+		expect(msg.to).toContain('test2@localhost');
+		expect((msg.text ?? '').trim()).toBe('This is the email body content.');
+	});
+});
+
+describe('SmtpSink - EHLO', () => {
+	it('advertises SIZE and PIPELINING', async () => {
+		// RFC 1870 section 3 (SIZE) and RFC 2920 section 3 (PIPELINING) ESMTP keywords.
+		const client = createClient();
+		await client.read();
+		const lines = await ehlo(client);
+		const joined = lines.join('\n');
+		expect(joined).toMatch(/SIZE/);
+		expect(joined).toMatch(/PIPELINING/);
+	});
+
+	it('advertises AUTH when mechs are configured', async () => {
+		// RFC 4954 section 3: the AUTH EHLO keyword is advertised with a
+		// space-separated list of available SASL mechanism names as
+		// its parameter.
+		const client = createClient({
+			auth: { mechs: ['PLAIN', 'LOGIN'] },
+		});
+		await client.read();
+		const lines = await ehlo(client);
+		const joined = lines.join('\n');
+		expect(joined).toMatch(/AUTH PLAIN LOGIN/);
+	});
+
+	it('does not advertise STARTTLS', async () => {
+		// The sink runs over an in-process loopback duplex with
+		// nothing to encrypt, so STARTTLS is never offered. Clients
+		// that need TLS must be configured for plain SMTP.
+		const client = createClient();
+		await client.read();
+		const lines = await ehlo(client);
+		const joined = lines.join('\n');
+		expect(joined).not.toMatch(/STARTTLS/);
+	});
+
+	it('HELO returns a single-line greeting with no extension lines', async () => {
+		// RFC 5321 section 4.1.1.1: HELO is the legacy non-extended greeting,
+		// so it must NOT advertise ESMTP extensions.
+		const client = createClient({
+			auth: { mechs: ['PLAIN'] },
+		});
+		await client.read();
+		await client.write('HELO localhost\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(/^250 /);
+		expect(resp).not.toMatch(/^250-/m);
+		expect(resp).not.toMatch(/AUTH/);
+		expect(resp).not.toMatch(/SIZE/);
+		expect(resp).not.toMatch(/PIPELINING/);
+	});
+
+	it('rejects EHLO with no domain argument', async () => {
+		// RFC 5321 section 4.1.1.1 ABNF:
+		//   ehlo = "EHLO" SP ( Domain / address-literal ) CRLF
+		// The Domain (or address-literal) is a required production,
+		// so a bare "EHLO\r\n" is a syntax error.
+		const client = createClient();
+		await client.read();
+		await client.write('EHLO\r\n');
+		expect(await client.read()).toMatch(/^501 /);
+	});
+
+	it('rejects HELO with no domain argument', async () => {
+		// RFC 5321 section 4.1.1.1 ABNF:
+		//   helo = "HELO" SP Domain CRLF
+		// Domain is mandatory; a bare "HELO\r\n" is a syntax error.
+		const client = createClient();
+		await client.read();
+		await client.write('HELO\r\n');
+		expect(await client.read()).toMatch(/^501 /);
+	});
+
+	it('EHLO greeting line starts with the server domain, not free-form text', async () => {
+		// RFC 5321 section 4.1.1.1 ABNF:
+		//   ehlo-ok-rsp = "250-" Domain [ SP ehlo-greet ] CRLF
+		//                 *( "250-" ehlo-line CRLF )
+		//                 "250" SP ehlo-line CRLF
+		// The first token after "250-" MUST be the server's Domain;
+		// any free-form `ehlo-greet` follows after a single SP.
+		const client = createClient();
+		await client.read();
+		await client.write('EHLO client.example.com\r\n');
+		const first = await client.read();
+		// The first reply line is "250-<Domain>[ SP ehlo-greet]".
+		// The greeter is "localhost", matching the 220 banner.
+		expect(first).toMatch(/^250-localhost(\s|\r\n)/);
+	});
+
+	it('HELO greeting line starts with the server domain', async () => {
+		// RFC 5321 section 4.1.1.1 ABNF for HELO uses the same single-line
+		// `"250" SP Domain [ SP ehlo-greet ]` shape.
+		const client = createClient();
+		await client.read();
+		await client.write('HELO client.example.com\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(/^250 localhost(\s|\r\n)/);
+	});
+});
+
+describe('SmtpSink - STARTTLS', () => {
+	it('refuses STARTTLS with 502', async () => {
+		// RFC 5321 section 4.2.4: an unimplemented command is answered with
+		// 502. The sink never advertises STARTTLS in EHLO, so a
+		// client that issues it anyway is treated as having sent an
+		// unrecognized command.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('STARTTLS\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(/^502 /);
+	});
+});
+
+describe('SmtpSink - AUTH PLAIN', () => {
+	it('accepts valid credentials inline', async () => {
+		// RFC 4954 section 4 (initial-response form) + RFC 4616 section 2 (PLAIN
+		// SASL message: [authzid] UTF8NUL authcid UTF8NUL passwd).
+		// Success returns 235.
+		const client = createClient({
+			auth: { mechs: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		// PLAIN: \0username\0password in base64
+		const creds = btoa('\0user\0pass');
+		await client.write(`AUTH PLAIN ${creds}\r\n`);
+		const resp = await client.read();
+		expect(resp).toMatch(/^235 /);
+	});
+
+	it('accepts valid credentials via challenge-response', async () => {
+		// RFC 4954 section 4: when no initial response is supplied, the server
+		// issues "334 " with an empty challenge and the client follows
+		// up with the SASL response on its own line.
+		const client = createClient({
+			auth: { mechs: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('AUTH PLAIN\r\n');
+		const challenge = await client.read();
+		expect(challenge).toMatch(/^334 /);
+		const creds = btoa('\0user\0pass');
+		await client.write(`${creds}\r\n`);
+		const resp = await client.read();
+		expect(resp).toMatch(/^235 /);
+	});
+
+	it('rejects invalid credentials', async () => {
+		// RFC 4954 section 6: bad credentials produce "535 5.7.8
+		// Authentication credentials invalid".
+		const client = createClient({
+			auth: {
+				mechs: ['PLAIN'],
+				validator: async (_mech, { username, password }) =>
+					username === 'admin' && password === 'secret',
+			},
+		});
+		await client.read();
+		await ehlo(client);
+		const creds = btoa('\0wrong\0creds');
+		await client.write(`AUTH PLAIN ${creds}\r\n`);
+		const resp = await client.read();
+		expect(resp).toMatch(/^535 /);
+	});
+
+	it('allows cancellation with *', async () => {
+		// RFC 4954 section 4: a single "*" sent in place of a SASL response
+		// cancels the AUTH exchange; the server returns 501.
+		const client = createClient({
+			auth: { mechs: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('AUTH PLAIN\r\n');
+		await client.read();
+		await client.write('*\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(/^501 /);
+	});
+});
+
+describe('SmtpSink - AUTH LOGIN', () => {
+	it('completes multi-step LOGIN flow', async () => {
+		// LOGIN SASL is non-standard (draft-murchison-sasl-login) but
+		// universally deployed: server prompts with base64("Username:")
+		// then base64("Password:") via 334 challenges, then 235 on
+		// success per RFC 4954 section 4.
+		const client = createClient({
+			auth: { mechs: ['LOGIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('AUTH LOGIN\r\n');
+		const usernameChallenge = await client.read();
+		expect(usernameChallenge).toMatch(/^334 /);
+		await client.write(`${btoa('myuser')}\r\n`);
+		const passwordChallenge = await client.read();
+		expect(passwordChallenge).toMatch(/^334 /);
+		await client.write(`${btoa('mypass')}\r\n`);
+		const resp = await client.read();
+		expect(resp).toMatch(/^235 /);
+	});
+
+	it('accepts initial-response as username', async () => {
+		// RFC 4954 section 4: clients may bundle the first SASL response onto
+		// the AUTH command line. For LOGIN that response is the
+		// username, so the server skips straight to the password
+		// challenge.
+		const client = createClient({
+			auth: { mechs: ['LOGIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write(`AUTH LOGIN ${btoa('myuser')}\r\n`);
+		const passwordChallenge = await client.read();
+		expect(passwordChallenge).toMatch(/^334 /);
+		await client.write(`${btoa('mypass')}\r\n`);
+		const resp = await client.read();
+		expect(resp).toMatch(/^235 /);
+	});
+
+	it('rejects invalid LOGIN credentials', async () => {
+		// RFC 4954 section 6: failed authentication exchange returns 535.
+		const client = createClient({
+			auth: {
+				mechs: ['LOGIN'],
+				validator: async () => false,
+			},
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('AUTH LOGIN\r\n');
+		await client.read();
+		await client.write(`${btoa('user')}\r\n`);
+		await client.read();
+		await client.write(`${btoa('wrong')}\r\n`);
+		const resp = await client.read();
+		expect(resp).toMatch(/^535 /);
+	});
+});
+
+describe('SmtpSink - AUTH edge cases', () => {
+	it('rejects AUTH with no mechanism', async () => {
+		// RFC 4954 section 4: AUTH command requires a mechanism argument;
+		// the server replies 501 on syntax errors.
+		const client = createClient({
+			auth: { mechs: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('AUTH\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(/^501 /);
+	});
+
+	it('rejects already-authenticated client', async () => {
+		// RFC 4954 section 4: after a successful AUTH, further AUTH commands
+		// in the same session must be rejected with 503.
+		const client = createClient({
+			auth: { mechs: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		const creds = btoa('\0u\0p');
+		await client.write(`AUTH PLAIN ${creds}\r\n`);
+		await client.read();
+		await client.write(`AUTH PLAIN ${creds}\r\n`);
+		const resp = await client.read();
+		expect(resp).toMatch(/^503 /);
+	});
+
+	it('rejects unrecognized auth mechanism', async () => {
+		// RFC 4954 section 4: a SASL mechanism the server doesn't support
+		// produces "504 5.5.4 Unrecognized authentication type".
+		const client = createClient({
+			auth: { mechs: ['PLAIN'] },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('AUTH CRAM-MD5\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(/^504 /);
+	});
+
+	it('rejects MAIL/RCPT when requireAuth and not authenticated', async () => {
+		// RFC 4954 section 6: "530 5.7.0 Authentication required" SHOULD be
+		// returned by any command other than AUTH/EHLO/HELO/NOOP/RSET/
+		// QUIT when server policy requires authentication and the
+		// session is not yet authenticated.
+		const client = createClient({
+			auth: { mechs: ['PLAIN'], requireAuth: true },
+		});
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		const mailResp = await client.read();
+		expect(mailResp).toMatch(/^530 /);
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		const rcptResp = await client.read();
+		expect(rcptResp).toMatch(/^530 /);
+	});
+});
+
+describe('SmtpSink - command edge cases', () => {
+	it('RSET clears the envelope', async () => {
+		// RFC 5321 section 4.1.1.5: RSET aborts the current mail transaction
+		// and clears reverse-path / forward-paths / mail data buffers,
+		// then the server replies 250.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		await client.read();
+		await client.write('RSET\r\n');
+		const rsetResp = await client.read();
+		expect(rsetResp).toMatch(/^250 /);
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		const rcptResp = await client.read();
+		expect(rcptResp).toMatch(/^503 /);
+	});
+
+	it('mid-session EHLO clears the envelope (RFC 5321 section 4.1.4)', async () => {
+		// Regression: previously EHLO only set state='idle' without
+		// clearing buffers, leaking mailFrom/rcpts across sessions.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		await client.read();
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		await client.read();
+		await ehlo(client);
+		await client.write('RCPT TO:<e@f.com>\r\n');
+		expect(await client.read()).toMatch(/^503 /);
+		await client.write('DATA\r\n');
+		expect(await client.read()).toMatch(/^503 /);
+	});
+
+	it('drops the connection with 500 when a command line exceeds 512 octets', async () => {
+		// RFC 5321 section 4.5.3.1.4: "The maximum total length of a command
+		// line including the command word and the <CRLF> is 512
+		// octets." Outside of DATA mode the sink must refuse an
+		// un-terminated tail that has already exceeded that limit
+		// instead of growing lineBuf without bound.
+		const client = createClient();
+		await client.read();
+		// 600 bytes of garbage with no CRLF - comfortably over 512
+		// but under the 1000-octet text-line limit, proving the sink
+		// uses the *command* limit when not in DATA mode.
+		await client.write('A'.repeat(600));
+		const resp = await client.read();
+		expect(resp).toMatch(/^500 /);
+		await expect(client.read()).resolves.toBe('');
+	});
+
+	it('drops the connection with 500 when a DATA text line exceeds 1000 octets', async () => {
+		// RFC 5321 section 4.5.3.1.6: "The maximum total length of a text
+		// line including the <CRLF> is 1000 octets." Inside DATA mode
+		// the sink applies the larger text-line limit; an
+		// un-terminated 1500-byte tail crosses it and must be
+		// refused.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('DATA\r\n');
+		expect(await client.read()).toMatch(/^354 /);
+		await client.write('Subject: Big\r\n\r\n');
+		// 1500 bytes of body with no CRLF - over the 1000-octet
+		// text-line limit.
+		await client.write('A'.repeat(1500));
+		const resp = await client.read();
+		expect(resp).toMatch(/^500 /);
+		await expect(client.read()).resolves.toBe('');
+	});
+
+	it('accepts a command line just under the 512-octet limit', async () => {
+		// RFC 5321 section 4.5.3.1.4 caps command lines at 512 octets
+		// *including the CRLF*, so any compliant command can carry
+		// up to 510 octets of payload. NOOP accepts an arbitrary
+		// trailing string per section 4.1.1.9, which gives us a clean way
+		// to test the upper bound without invoking another command's
+		// argument validation.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		// "NOOP " (5) + 505 chars + "\r\n" (2) = 512 octets total.
+		await client.write('NOOP ' + 'A'.repeat(505) + '\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+	});
+
+	it('NOOP returns 250', async () => {
+		// RFC 5321 section 4.1.1.9: NOOP has no effect on parameters or
+		// previously entered commands and always succeeds with 250.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('NOOP\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+	});
+
+	it('VRFY returns 252', async () => {
+		// RFC 5321 section 3.5.3 / section 4.1.1.6: a server that does not verify
+		// addresses but is willing to accept the message answers VRFY
+		// with "252 Cannot VRFY user, but will accept message".
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('VRFY user\r\n');
+		expect(await client.read()).toMatch(/^252 /);
+	});
+
+	it('unknown command returns 500', async () => {
+		// RFC 5321 section 4.2.4: an unrecognized command produces 500
+		// "Syntax error, command unrecognized".
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('XYZZY\r\n');
+		expect(await client.read()).toMatch(/^500 /);
+	});
+
+	it.each(['EXPN', 'HELP', 'TURN'])(
+		'recognized but unimplemented command %s returns 502',
+		async (cmd) => {
+			// RFC 5321 section 4.2.4: a recognized but unimplemented command
+			// produces 502 "Command not implemented". EXPN and HELP
+			// are optional per section 4.1.1.7 / section 4.1.1.8; TURN is the
+			// historical RFC 821 reverse-direction command, listed
+			// among RFC 821 features deprecated in RFC 5321 Appendix
+			// F.1.
+			const client = createClient();
+			await client.read();
+			await ehlo(client);
+			await client.write(`${cmd}\r\n`);
+			expect(await client.read()).toMatch(/^502 /);
+		}
+	);
+
+	it('rejects MAIL FROM with bad syntax', async () => {
+		// RFC 5321 section 4.1.1.2: the MAIL command requires "FROM:" and a
+		// reverse-path; malformed input yields 501.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL TO:<a@b.com>\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(/^501 /);
+	});
+
+	it('rejects RCPT TO with bad syntax', async () => {
+		// RFC 5321 section 4.1.1.3: the RCPT command requires "TO:" and a
+		// forward-path; malformed input yields 501.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('RCPT FROM:<a@b.com>\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(/^501 /);
+	});
+
+	it('rejects MAIL FROM with a space after the colon', async () => {
+		// RFC 5321 section 3.3: "spaces are not permitted on either side of
+		// the colon following FROM in the MAIL command or TO in the
+		// RCPT command. The syntax is exactly as given above." This
+		// is called out explicitly because it has been "a common
+		// source of errors".
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM: <a@b.com>\r\n');
+		expect(await client.read()).toMatch(/^501 /);
+	});
+
+	it('rejects RCPT TO with a space after the colon', async () => {
+		// RFC 5321 section 3.3: same no-space rule as MAIL FROM. The session
+		// must be in the mail state for the rejection to be a syntax
+		// error rather than a sequence error, so set up MAIL first.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO: <c@d.com>\r\n');
+		expect(await client.read()).toMatch(/^501 /);
+	});
+
+	it('rejects MAIL FROM without angle brackets', async () => {
+		// RFC 5321 section 4.1.2 ABNF: Reverse-path is `Path / "<>"` and
+		// `Path = "<" [ A-d-l ":" ] Mailbox ">"`. The angle brackets
+		// are mandatory; a bare addr-spec is a syntax error.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:a@b.com\r\n');
+		expect(await client.read()).toMatch(/^501 /);
+	});
+
+	it('rejects RCPT TO without angle brackets', async () => {
+		// RFC 5321 section 4.1.2: Forward-path uses the same `Path`
+		// production as Reverse-path, so the brackets are required
+		// here too.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO:c@d.com\r\n');
+		expect(await client.read()).toMatch(/^501 /);
+	});
+
+	it('accepts MAIL FROM with trailing ESMTP parameters', async () => {
+		// RFC 5321 section 4.1.1.2 ABNF:
+		//   mail = "MAIL FROM:" Reverse-path
+		//          [SP Mail-parameters] CRLF
+		// A single SP separates the closing `>` of the path from the
+		// optional ESMTP parameter list (e.g. RFC 1870 SIZE=N). The
+		// sink must accept the path and ignore the parameters.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com> SIZE=42\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+	});
+
+	it('rejects RCPT before MAIL', async () => {
+		// RFC 5321 section 3.3 + section 4.1.1.3: RCPT TO can only follow a MAIL
+		// FROM in the current transaction; otherwise the server
+		// answers 503 "Bad sequence of commands".
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('RCPT TO:<a@b.com>\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(/^503 /);
+	});
+
+	it('rejects DATA before MAIL/RCPT', async () => {
+		// RFC 5321 section 3.3 + section 4.1.1.4: DATA requires at least one
+		// successful RCPT (which itself requires a MAIL FROM); else
+		// the server answers 503 "Bad sequence of commands".
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('DATA\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(/^503 /);
+	});
+
+	it('QUIT returns 221 and closes', async () => {
+		// RFC 5321 section 4.1.1.10: the receiver MUST send "221 <domain>
+		// Service closing transmission channel" and then close the
+		// transmission channel.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('QUIT\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(/^221 /);
+	});
+});
+
+describe('SmtpSink - data handling', () => {
+	it('handles dot-stuffing (lines starting with ..)', async () => {
+		// RFC 5321 section 4.5.2 (transparency): a leading "." on a body line
+		// is doubled by the sender and stripped by the receiver so the
+		// end-of-data marker (a bare "." line) cannot be confused with
+		// content.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		await client.read();
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		await client.read();
+		await client.write('DATA\r\n');
+		await client.read();
+		await client.write('Subject: Dots\r\n');
+		await client.write('\r\n');
+		// A line that starts with a dot must be dot-stuffed by the client
+		await client.write('..This line started with a dot.\r\n');
+		await client.write('Normal line.\r\n');
+		await client.write('.\r\n');
+		await client.read(); // 250 Queued
+
+		expect(client.messages).toHaveLength(1);
+		expect(client.messages[0].text).toContain(
+			'.This line started with a dot.'
+		);
+		expect(client.messages[0].text).toContain('Normal line.');
+	});
+
+	it('rejects message exceeding maxSize', async () => {
+		// RFC 1870 section 6.3: when the message exceeds the SIZE the server
+		// declared, the server returns "552 Message size exceeds fixed
+		// maximum message size" after the end-of-data marker.
+		const client = createClient({ maxSize: 100 });
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		await client.read();
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		await client.read();
+		await client.write('DATA\r\n');
+		await client.read();
+		await client.write('Subject: Big\r\n');
+		await client.write('\r\n');
+		await client.write('X'.repeat(200) + '\r\n');
+		await client.write('.\r\n');
+		const resp = await client.read();
+		expect(resp).toMatch(/^552 /);
+		expect(client.messages).toHaveLength(0);
+	});
+
+	it('drains DATA after maxSize overflow and keeps session usable', async () => {
+		// Regression: issuing 552 before end-of-data flips out of
+		// dataMode, so remaining body lines are parsed as SMTP commands
+		// and the session is poisoned. RFC 1870 section 6.3 requires the 552
+		// to come *after* the end-of-data marker.
+		const client = createClient({ maxSize: 100 });
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		await client.read();
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		await client.read();
+		await client.write('DATA\r\n');
+		await client.read();
+
+		let body = 'Subject: Big\r\n\r\n';
+		for (let i = 0; i < 200; i++) body += `line${i}\r\n`;
+		body += '.\r\n';
+		await client.write(body);
+
+		expect(await client.read()).toMatch(/^552 /);
+		expect(client.messages).toHaveLength(0);
+
+		await client.write('MAIL FROM:<a@b.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO:<c@d.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('DATA\r\n');
+		expect(await client.read()).toMatch(/^354 /);
+		await client.write('Subject: Small\r\n\r\nbody\r\n.\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+
+		expect(client.messages).toHaveLength(1);
+		expect(client.messages[0].subject).toBe('Small');
+	});
+
+	it('accepts the null reverse-path MAIL FROM:<> for bounce messages', async () => {
+		// RFC 5321 section 4.5.5: bounce messages use a null reverse-path,
+		// `MAIL FROM:<>`. extractPath previously rejected `<>` and
+		// `mailFrom` was left in an undefined state that broke RCPT.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+		await client.write('MAIL FROM:<>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO:<postmaster@local>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('DATA\r\n');
+		expect(await client.read()).toMatch(/^354 /);
+		await client.write('Subject: Bounce\r\n\r\nDelivery failed.\r\n.\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		expect(client.messages).toHaveLength(1);
+		// Empty envelope-from is preserved (not the literal string "<>").
+		// The parsed `from` falls back to the envelope value when no
+		// From: header is present, so it should be empty here.
+		expect(client.messages[0].from).toBe('');
+	});
+
+	it('sends multiple emails in one session', async () => {
+		// RFC 5321 section 3.3: a transaction starts with MAIL, accepts one
+		// or more RCPTs, and is committed by DATA followed by the
+		// end-of-data marker. A session may carry further transactions
+		// without re-issuing HELO/EHLO; the spec contemplates this
+		// when it lets a new MAIL command (or RSET) reset all state
+		// tables and buffers.
+		const client = createClient();
+		await client.read();
+		await ehlo(client);
+
+		await client.write('MAIL FROM:<s@test.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO:<a@test.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('DATA\r\n');
+		expect(await client.read()).toMatch(/^354 /);
+		await client.write('Subject: First\r\n\r\nBody 1\r\n.\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+
+		await client.write('MAIL FROM:<s@test.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('RCPT TO:<b@test.com>\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+		await client.write('DATA\r\n');
+		expect(await client.read()).toMatch(/^354 /);
+		await client.write('Subject: Second\r\n\r\nBody 2\r\n.\r\n');
+		expect(await client.read()).toMatch(/^250 /);
+
+		expect(client.messages).toHaveLength(2);
+		expect(client.messages[0].subject).toBe('First');
+		expect(client.messages[1].subject).toBe('Second');
+	});
+});
+
+describe('parseMessage', () => {
+	it('parses a simple text/plain email', () => {
+		// RFC 5322 section 2.1: a message is header fields followed by an
+		// empty line followed by the body. RFC 2045 section 5 defaults the
+		// Content-Type to text/plain when no header is present.
+		const raw =
+			'Subject: Hello\r\n' +
+			'From: a@b.com\r\n' +
+			'To: c@d.com\r\n' +
+			'\r\n' +
+			'Body text here.\r\n';
+		const result = parseMessage(raw, 'fallback@x.com', ['fb@y.com']);
+		expect(result.subject).toBe('Hello');
+		expect(result.from).toBe('a@b.com');
+		expect(result.to).toBe('c@d.com');
+		expect(result.text?.trim()).toBe('Body text here.');
+	});
+
+	it('preserves all recipients from a multi-recipient To header', () => {
+		// RFC 5322 section 3.4: an address-list is a comma-separated sequence
+		// of mailbox / group productions, mixing "Display Name <addr>"
+		// and bare addr-spec forms.
+		const raw =
+			'From: sender@test.com\r\n' +
+			'To: Foo Bar <foo@test.com>, bare@test.com, ' +
+			'"Quoted Name" <quoted@test.com>\r\n' +
+			'Subject: Multi recipient\r\n' +
+			'\r\n' +
+			'Body.\r\n';
+		const result = parseMessage(raw, '', []);
+		expect(result.to).toContain('foo@test.com');
+		expect(result.to).toContain('bare@test.com');
+		expect(result.to).toContain('quoted@test.com');
+	});
+
+	it('uses fallback from/to when headers are missing', () => {
+		// RFC 5321 section 2.3.1 (Mail Objects): a mail object has an
+		// envelope (MAIL FROM / RCPT TO) and a content with its own
+		// header section. When the header omits From:/To: we fall
+		// back to the envelope values supplied by the SMTP
+		// transaction.
+		const raw = 'Subject: No addrs\r\n\r\nBody.\r\n';
+		const result = parseMessage(raw, 'env@from.com', [
+			'env@to1.com',
+			'env@to2.com',
+		]);
+		expect(result.from).toBe('env@from.com');
+		expect(result.to).toBe('env@to1.com, env@to2.com');
+	});
+
+	it('shows (no subject) when Subject header is missing', () => {
+		// RFC 5322 section 3.6.5: Subject is an optional header field. No
+		// spec mandates a placeholder; "(no subject)" is the
+		// long-standing MUA convention.
+		const raw = 'From: a@b.com\r\n\r\nBody.\r\n';
+		const result = parseMessage(raw, '', []);
+		expect(result.subject).toBe('(no subject)');
+	});
+
+	it('decodes RFC 2047 base64 encoded subject', () => {
+		// RFC 2047 section 4.1: encoded-word with "B" encoding wraps base64
+		// of the byte sequence in the named charset.
+		// "Test" in base64
+		const encoded = '=?utf-8?B?VGVzdA==?=';
+		const raw = `Subject: ${encoded}\r\n\r\nBody.\r\n`;
+		const result = parseMessage(raw, '', []);
+		expect(result.subject).toBe('Test');
+	});
+
+	it('decodes RFC 2047 Q-encoded subject', () => {
+		// RFC 2047 section 4.2: Q-encoding is a quoted-printable variant
+		// where "_" represents 0x20 (space) inside encoded-words.
+		// "Hello World" Q-encoded (underscore = space)
+		const encoded = '=?utf-8?Q?Hello_World?=';
+		const raw = `Subject: ${encoded}\r\n\r\nBody.\r\n`;
+		const result = parseMessage(raw, '', []);
+		expect(result.subject).toBe('Hello World');
+	});
+
+	it('decodes quoted-printable body', () => {
+		// RFC 2045 section 6.7: quoted-printable encodes non-ASCII octets as
+		// "=XX" hex escapes; the receiver reverses the escape using
+		// the declared charset.
+		const raw =
+			'Subject: QP\r\n' +
+			'Content-Type: text/plain; charset=utf-8\r\n' +
+			'Content-Transfer-Encoding: quoted-printable\r\n' +
+			'\r\n' +
+			'Hello =C3=A9 world\r\n';
+		const result = parseMessage(raw, '', []);
+		expect(result.text).toContain('Hello é world');
+	});
+
+	it('decodes base64 body', () => {
+		// RFC 2045 section 6.8: base64 encodes arbitrary octet streams in a
+		// 65-character ASCII subset for transport over 7-bit channels.
+		const raw =
+			'Subject: B64\r\n' +
+			'Content-Type: text/plain; charset=utf-8\r\n' +
+			'Content-Transfer-Encoding: base64\r\n' +
+			'\r\n' +
+			btoa('Decoded body content') +
+			'\r\n';
+		const result = parseMessage(raw, '', []);
+		expect(result.text?.trim()).toBe('Decoded body content');
+	});
+
+	it('extracts text/plain from multipart email', () => {
+		// RFC 2046 section 5.1: multipart bodies are split by a "--boundary"
+		// delimiter and terminated by "--boundary--". multipart/
+		// alternative (section 5.1.4) lets a sender supply the same content
+		// in several formats; receivers pick the best they can render.
+		const boundary = 'BOUNDARY123';
+		const raw =
+			`Subject: Multi\r\n` +
+			`Content-Type: multipart/alternative; boundary="${boundary}"\r\n` +
+			`\r\n` +
+			`--${boundary}\r\n` +
+			`Content-Type: text/plain; charset=utf-8\r\n` +
+			`\r\n` +
+			`Plain text part.\r\n` +
+			`--${boundary}\r\n` +
+			`Content-Type: text/html; charset=utf-8\r\n` +
+			`\r\n` +
+			`<p>HTML part.</p>\r\n` +
+			`--${boundary}--\r\n`;
+		const result = parseMessage(raw, '', []);
+		expect(result.subject).toBe('Multi');
+		expect(result.text?.trim()).toBe('Plain text part.');
+	});
+
+	it('handles folded headers', () => {
+		// RFC 5322 section 2.2.3: a long header field may be split onto
+		// multiple lines by inserting CRLF before any WSP. The
+		// receiver "unfolds" by removing the CRLF before the WSP.
+		const raw =
+			'Subject: This is a very long\r\n' +
+			' subject line that was folded\r\n' +
+			'From: a@b.com\r\n' +
+			'\r\n' +
+			'Body.\r\n';
+		const result = parseMessage(raw, '', []);
+		expect(result.subject).toBe(
+			'This is a very long subject line that was folded'
+		);
+	});
+
+	it('handles email with no body', () => {
+		// RFC 5322 section 2.1: a body is OPTIONAL; if present it is
+		// separated from the headers by a single empty line. With no
+		// separator the body is empty.
+		const raw = 'Subject: Empty\r\nFrom: a@b.com\r\n';
+		const result = parseMessage(raw, '', []);
+		expect(result.subject).toBe('Empty');
+		expect(result.text).toBe('');
+	});
+});

--- a/packages/php-wasm/util/src/lib/smtp.ts
+++ b/packages/php-wasm/util/src/lib/smtp.ts
@@ -1,0 +1,764 @@
+export type ByteDuplex = {
+	readable: ReadableStream<Uint8Array>;
+	writable: WritableStream<Uint8Array>;
+};
+
+export type CaughtMessage = {
+	receivedAt: string;
+	from: string;
+	to: string;
+	subject: string;
+	headers: Record<string, string>;
+	text?: string;
+	raw: string;
+	rawSize: number;
+};
+
+type SaslMech = 'PLAIN' | 'LOGIN';
+
+// Server identifier used in the 220 greeting and as the Domain
+// token in the EHLO/HELO 250 response (RFC 5321 section 4.1.1.1 ABNF
+// requires the first token after "250"/"250-" to be a Domain).
+const SERVER_NAME = 'localhost';
+
+export type AuthValidator = (
+	mech: SaslMech,
+	cred: { username: string; password: string }
+) => boolean | Promise<boolean>;
+
+export type SmtpSinkOptions = {
+	maxSize?: number;
+	auth?: {
+		mechs?: SaslMech[]; // which mechanisms to offer
+		advertise?: boolean; // show AUTH on EHLO
+		requireAuth?: boolean; // 530 before MAIL/RCPT unless authenticated
+		validator?: AuthValidator; // check creds; default accepts anything
+	};
+};
+
+/**
+ * SMTP server sink that receives emails and invokes a callback for
+ * each fully-received message.
+ */
+export class SmtpSink {
+	private enc = new TextEncoder();
+	private dec = new TextDecoder();
+	private lineBuf = '';
+	private dataMode = false;
+	private dataLines: string[] = [];
+	private dataBytes = 0;
+	private mailFrom: string | null = null;
+	private rcpts: string[] = [];
+	private writer: WritableStreamDefaultWriter<Uint8Array>;
+	private reader: ReadableStreamDefaultReader<Uint8Array>;
+	private closed = false;
+	private readonly maxSize: number;
+
+	// sequencing so replies stay in order
+	private seq: Promise<void> = Promise.resolve();
+
+	// AUTH policy
+	private authAdvertise: boolean;
+	private authMechs: SaslMech[];
+	private authRequire: boolean;
+	private authValidator: AuthValidator;
+	private authenticated = false;
+	private authPending = false;
+	private authState:
+		| { mech: 'PLAIN'; stage: 'waitInitial' }
+		| { mech: 'LOGIN'; stage: 'username' | 'password'; username?: string }
+		| null = null;
+
+	private onEmail: (m: CaughtMessage) => void;
+
+	constructor(
+		duplex: ByteDuplex,
+		onEmail: (m: CaughtMessage) => void,
+		opts: SmtpSinkOptions = {}
+	) {
+		this.onEmail = onEmail;
+		this.writer = duplex.writable.getWriter();
+		this.reader = duplex.readable.getReader();
+		this.maxSize = opts.maxSize ?? 10 * 1024 * 1024;
+
+		this.authMechs = opts.auth?.mechs ?? [];
+		this.authAdvertise = opts.auth?.advertise ?? this.authMechs.length > 0;
+		this.authRequire = opts.auth?.requireAuth ?? false;
+		this.authValidator = opts.auth?.validator ?? (async () => true);
+	}
+
+	async start(): Promise<void> {
+		await this.reply(220, `${SERVER_NAME} ESMTP ready`);
+		for (;;) {
+			const r = await this.reader.read();
+			if (r.done) break;
+			this.consumeChunk(r.value);
+			if (this.closed) break;
+		}
+		// Wait for all enqueued handlers to finish before closing
+		// the writer. When the client closes the connection, the
+		// reader gets done immediately, but enqueued handlers
+		// (like handleDataLine(".") which delivers the email) may
+		// still be pending in the promise chain.
+		await this.seq;
+		await this.close();
+	}
+
+	private async close(): Promise<void> {
+		if (this.closed) return;
+		this.closed = true;
+		await this.writer.close();
+	}
+
+	private consumeChunk(chunk: Uint8Array) {
+		const text = this.dec.decode(chunk, { stream: true });
+		this.lineBuf += text;
+
+		for (;;) {
+			const idx = this.lineBuf.indexOf('\r\n');
+			if (idx < 0) break;
+			const line = this.lineBuf.slice(0, idx);
+			this.lineBuf = this.lineBuf.slice(idx + 2);
+
+			this.enqueue(async () => {
+				if (this.dataMode) {
+					await this.handleDataLine(line);
+				} else if (this.authPending) {
+					await this.handleAuthLine(line);
+				} else {
+					await this.handleCommand(line);
+				}
+			});
+			if (this.closed) return;
+		}
+
+		// RFC 5321 section 4.5.3.1.4: command lines (incl. CRLF) <= 512
+		// octets. section 4.5.3.1.6: text lines (incl. CRLF) <= 1000 octets.
+		// If the un-terminated tail of lineBuf has already grown past
+		// the limit that applies to the current mode, the peer is
+		// malformed (or hostile); refuse it and drop the session
+		// rather than letting lineBuf grow without bound.
+		const maxLineLen = this.dataMode ? 1000 : 512;
+		if (this.lineBuf.length > maxLineLen) {
+			this.lineBuf = '';
+			this.enqueue(async () => {
+				await this.reply(500, 'line too long');
+				await this.close();
+			});
+		}
+	}
+
+	private enqueue(fn: () => Promise<void>) {
+		this.seq = this.seq.then(fn);
+	}
+
+	private async handleCommand(rawLine: string) {
+		const line = rawLine.trimEnd();
+		const sp = line.indexOf(' ');
+		const cmd = (sp < 0 ? line : line.slice(0, sp)).toUpperCase();
+		const arg = sp < 0 ? '' : line.slice(sp + 1);
+
+		switch (cmd) {
+			case 'EHLO':
+			case 'HELO': {
+				// RFC 5321 section 4.1.1.1 ABNF: both `helo` and `ehlo`
+				// require a Domain (or address-literal for EHLO)
+				// argument; an empty argument is a syntax error.
+				if (!arg.trim()) {
+					await this.reply(501, `syntax: ${cmd} <domain>`);
+					break;
+				}
+				// RFC 5321 section 4.1.4: a successful EHLO/HELO issued mid-
+				// session MUST clear all buffers and reset state exactly
+				// as RSET would. Auth state is preserved (RFC 4954 section 4).
+				this.resetEnvelope();
+				if (cmd === 'HELO') {
+					// RFC 5321 section 4.1.1.1 ABNF:
+					//   ehlo-ok-rsp = "250" SP Domain [ SP ehlo-greet ]
+					// HELO uses the same single-line form. The first
+					// token after the reply code MUST be the server's
+					// Domain, optionally followed by free-form text.
+					await this.reply(250, `${SERVER_NAME} Hello ${arg}`);
+					break;
+				}
+				// RFC 5321 section 4.1.1.1 ABNF for the multi-line response:
+				//   "250-" Domain [ SP ehlo-greet ] CRLF
+				//   *( "250-" ehlo-line CRLF )
+				//   "250" SP ehlo-line CRLF
+				// The first line therefore starts with the server's
+				// Domain, never with free-form text.
+				const ext: string[] = [];
+				if (this.authAdvertise && this.authMechs.length) {
+					const list = this.authMechs.join(' ');
+					ext.push(`AUTH ${list}`, `AUTH=${list}`);
+				}
+				ext.push(`SIZE ${this.maxSize}`, 'PIPELINING');
+				await this.replyMulti(250, [
+					`${SERVER_NAME} Hello ${arg}`,
+					...ext,
+				]);
+				break;
+			}
+
+			case 'STARTTLS': {
+				// The loopback duplex carries no real network traffic
+				// so there is nothing to encrypt. STARTTLS is never
+				// advertised in EHLO and is always refused with 502
+				// "Command not implemented" if a client tries it
+				// anyway. Clients that need TLS should be configured
+				// for plain SMTP against this sink.
+				await this.reply(502, 'Command not implemented');
+				break;
+			}
+
+			case 'AUTH': {
+				const [mechRaw, initialRaw] = arg.split(/\s+/, 2);
+				const mech = (mechRaw || '').toUpperCase() as SaslMech;
+
+				if (!mech) {
+					await this.reply(
+						501,
+						'syntax: AUTH mechanism [initial-response]'
+					);
+					break;
+				}
+				if (this.authenticated) {
+					await this.reply(503, 'already authenticated');
+					break;
+				}
+
+				if (!this.authMechs.includes(mech)) {
+					await this.reply(504, 'Unrecognized authentication type');
+					break;
+				}
+
+				if (mech === 'PLAIN') {
+					const init = normalizeInitial(initialRaw);
+					if (init == null) {
+						this.authPending = true;
+						this.authState = {
+							mech: 'PLAIN',
+							stage: 'waitInitial',
+						};
+						await this.reply(334, ''); // empty challenge
+					} else {
+						const ok = await this.handleAuthPlain(init);
+						await this.finishAuth(ok);
+					}
+					break;
+				}
+
+				if (mech === 'LOGIN') {
+					const init = normalizeInitial(initialRaw);
+					if (init != null) {
+						// initial response is username
+						const username = b64DecodeText(init);
+						this.authPending = true;
+						this.authState = {
+							mech: 'LOGIN',
+							stage: 'password',
+							username,
+						};
+						await this.reply(334, b64('Password:'));
+					} else {
+						this.authPending = true;
+						this.authState = { mech: 'LOGIN', stage: 'username' };
+						await this.reply(334, b64('Username:'));
+					}
+					break;
+				}
+				break;
+			}
+
+			case 'MAIL': {
+				if (this.authRequire && !this.authenticated) {
+					await this.reply(530, 'Authentication required');
+					break;
+				}
+				// RFC 5321 section 3.3 + section 4.1.1.2: the syntax is exactly
+				// `MAIL FROM:<reverse-path>`. section 3.3 explicitly forbids
+				// "spaces on either side of the colon", and the
+				// reverse-path MUST be enclosed in angle brackets (or
+				// be the literal `<>` for the null reverse-path,
+				// section 4.5.5).
+				const path = parseEnvelopeArg(arg, 'FROM');
+				if (path === null) {
+					await this.reply(501, 'syntax: MAIL FROM:<addr>');
+					break;
+				}
+				this.mailFrom = path;
+				this.rcpts = [];
+				await this.reply(250, 'OK');
+				break;
+			}
+
+			case 'RCPT': {
+				if (this.authRequire && !this.authenticated) {
+					await this.reply(530, 'Authentication required');
+					break;
+				}
+				// RFC 5321 section 3.3 + section 4.1.1.3: the syntax is exactly
+				// `RCPT TO:<forward-path>`. Same no-space, mandatory-
+				// brackets rule as MAIL FROM.
+				const path = parseEnvelopeArg(arg, 'TO');
+				if (path === null) {
+					await this.reply(501, 'syntax: RCPT TO:<addr>');
+					break;
+				}
+				// Explicit null check (not falsy): an empty string is a
+				// valid null reverse-path (`MAIL FROM:<>`, RFC 5321
+				// section 4.5.5) and must not gate RCPT.
+				if (this.mailFrom === null) {
+					await this.reply(503, 'need MAIL FROM first');
+					break;
+				}
+				this.rcpts.push(path);
+				await this.reply(250, 'Accepted');
+				break;
+			}
+
+			case 'DATA': {
+				if (this.mailFrom === null || this.rcpts.length === 0) {
+					await this.reply(503, 'need MAIL/RCPT first');
+					break;
+				}
+				await this.reply(354, 'End data with <CR><LF>.<CR><LF>');
+				this.dataMode = true;
+				this.dataLines = [];
+				this.dataBytes = 0;
+				break;
+			}
+
+			case 'RSET':
+				this.resetEnvelope();
+				await this.reply(250, 'OK');
+				break;
+
+			case 'NOOP':
+				await this.reply(250, 'OK');
+				break;
+
+			case 'VRFY':
+				await this.reply(
+					252,
+					'Cannot VRFY user, but will accept message'
+				);
+				break;
+
+			case 'QUIT':
+				await this.reply(221, 'Bye');
+				await this.close();
+				break;
+
+			case 'EXPN':
+			case 'HELP':
+			case 'TURN':
+				await this.reply(502, 'Command not implemented');
+				break;
+
+			default:
+				await this.reply(500, 'command not recognized');
+				break;
+		}
+	}
+
+	private async handleDataLine(line: string) {
+		if (line === '.') {
+			this.dataMode = false;
+			if (this.dataBytes > this.maxSize) {
+				// RFC 1870 section 6.3: when the size overflow is discovered
+				// mid-stream, the 552 reply must come *after* the
+				// end-of-data marker. Anything else desyncs the session.
+				await this.reply(552, 'message size exceeds fixed limit');
+				this.resetEnvelope();
+				return;
+			}
+			const raw = this.dataLines.join('\r\n') + '\r\n';
+			const { headers, subject, text, from, to } = parseMessage(
+				raw,
+				this.mailFrom ?? '',
+				this.rcpts
+			);
+			const message: CaughtMessage = {
+				receivedAt: new Date().toISOString(),
+				from,
+				to,
+				subject,
+				headers,
+				text,
+				raw,
+				rawSize: this.dataBytes,
+			};
+
+			this.onEmail(message);
+
+			await this.reply(250, 'OK');
+			this.resetEnvelope();
+			return;
+		}
+
+		const actual = line.startsWith('..') ? line.slice(1) : line;
+		this.dataBytes += this.enc.encode(actual).byteLength + 2;
+		if (this.dataBytes <= this.maxSize) {
+			this.dataLines.push(actual);
+		}
+	}
+
+	private async handleAuthLine(line: string) {
+		if (!this.authState) {
+			this.authPending = false;
+			return;
+		}
+		if (line === '*') {
+			this.authPending = false;
+			this.authState = null;
+			await this.reply(501, 'Authentication canceled');
+			return;
+		}
+
+		if (this.authState.mech === 'PLAIN') {
+			const ok = await this.handleAuthPlain(line.trim());
+			await this.finishAuth(ok);
+			return;
+		}
+
+		if (this.authState.mech === 'LOGIN') {
+			if (this.authState.stage === 'username') {
+				const username = b64DecodeText(line.trim());
+				this.authState = { mech: 'LOGIN', stage: 'password', username };
+				await this.reply(334, b64('Password:'));
+				return;
+			}
+			if (this.authState.stage === 'password') {
+				const password = b64DecodeText(line.trim());
+				const ok = await this.authValidator('LOGIN', {
+					username: this.authState.username || '',
+					password,
+				});
+				await this.finishAuth(ok);
+				return;
+			}
+		}
+	}
+
+	private async handleAuthPlain(initialB64: string): Promise<boolean> {
+		let decoded = '';
+		try {
+			decoded = atob(initialB64);
+		} catch {
+			return false;
+		}
+		// formats: authzid\0authcid\0passwd  OR  \0authcid\0passwd
+		const parts = decoded.split('\u0000');
+		let username = '';
+		let password = '';
+		if (parts.length >= 3) {
+			username = parts[1] || '';
+			password = parts[2] || '';
+		} else if (parts.length === 2) {
+			username = parts[0] || '';
+			password = parts[1] || '';
+		} else {
+			return false;
+		}
+		return await this.authValidator('PLAIN', { username, password });
+	}
+
+	private async finishAuth(ok: boolean) {
+		this.authPending = false;
+		this.authState = null;
+		if (ok) {
+			this.authenticated = true;
+			await this.reply(235, 'Authentication succeeded');
+		} else {
+			await this.reply(535, 'Authentication credentials invalid');
+		}
+	}
+
+	private resetEnvelope() {
+		this.mailFrom = null;
+		this.rcpts = [];
+		this.dataMode = false;
+		this.dataLines = [];
+		this.dataBytes = 0;
+	}
+
+	private async reply(code: number, text: string) {
+		await this.writer.write(this.enc.encode(`${code} ${text}\r\n`));
+	}
+	private async replyMulti(code: number, lines: string[]) {
+		for (let i = 0; i < lines.length - 1; i++) {
+			await this.writer.write(this.enc.encode(`${code}-${lines[i]}\r\n`));
+		}
+		await this.writer.write(
+			this.enc.encode(`${code} ${lines[lines.length - 1]}\r\n`)
+		);
+	}
+}
+
+/**
+ * Parses the argument of a MAIL or RCPT command into the envelope
+ * path. Returns `null` if the syntax does not match RFC 5321.
+ *
+ * RFC 5321 section 3.3 + section 4.1.1.2/3 require:
+ *   - the keyword (`FROM` or `TO`) is followed immediately by a
+ *     colon, with NO whitespace on either side ("a common source
+ *     of errors", section 3.3)
+ *   - the path is enclosed in angle brackets, or is the literal
+ *     `<>` for the null reverse-path (section 4.5.5)
+ *   - any ESMTP Mail-parameters that follow MUST be separated
+ *     from the closing `>` by a single space (RFC 1870, RFC 4954)
+ */
+export function parseEnvelopeArg(
+	arg: string,
+	keyword: 'FROM' | 'TO'
+): string | null {
+	const prefix = `${keyword}:<`;
+	if (arg.length < prefix.length + 1) return null;
+	if (arg.slice(0, prefix.length).toUpperCase() !== prefix) {
+		return null;
+	}
+	const close = arg.indexOf('>', prefix.length);
+	if (close < 0) return null;
+	// Anything past the closing bracket must either be empty or
+	// begin with a single space introducing ESMTP parameters.
+	const tail = arg.slice(close + 1);
+	if (tail !== '' && !tail.startsWith(' ')) return null;
+	return arg.slice(prefix.length, close);
+}
+
+/**
+ * Extracts email addresses from an RFC 5322 address list.
+ * Handles a mix of "Name <addr>" and bare "addr" entries.
+ */
+export function extractAddresses(value: string): string[] {
+	const out: string[] = [];
+	for (const part of value.split(',')) {
+		const trimmed = part.trim();
+		if (!trimmed) continue;
+		const angle = trimmed.match(/<([^>]+)>/);
+		if (angle) {
+			out.push(angle[1].trim());
+		} else if (trimmed.includes('@')) {
+			out.push(trimmed);
+		}
+	}
+	return out;
+}
+
+export function unfoldHeaders(hdr: string): string {
+	return hdr.replace(/\r\n([ \t]+)/g, ' ');
+}
+export function splitHeaderBody(raw: string): {
+	headerRaw: string;
+	bodyRaw: string;
+} {
+	const idx = raw.indexOf('\r\n\r\n');
+	if (idx < 0) return { headerRaw: raw, bodyRaw: '' };
+	return { headerRaw: raw.slice(0, idx), bodyRaw: raw.slice(idx + 4) };
+}
+export function parseHeaderLines(headerRaw: string): Record<string, string> {
+	const out: Record<string, string> = {};
+	const unfolded = unfoldHeaders(headerRaw);
+	const lines = unfolded.split('\r\n');
+	for (const line of lines) {
+		const i = line.indexOf(':');
+		if (i <= 0) continue;
+		const name = line.slice(0, i).toLowerCase();
+		const val = line.slice(i + 1).trim();
+		out[name] = (out[name] ? out[name] + ', ' : '') + val;
+	}
+	return out;
+}
+function decodeRfc2047(s: string): string {
+	return s.replace(
+		/=\?([^?]+)\?([BbQq])\?([^?]+)\?=/g,
+		(_m, cs, enc, data) => {
+			const charset = String(cs);
+			const kind = String(enc).toUpperCase();
+			let bytes: Uint8Array;
+			if (kind === 'B') {
+				const bin = atob(String(data));
+				const arr = new Uint8Array(bin.length);
+				for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+				bytes = arr;
+			} else {
+				let txt = String(data).replace(/_/g, ' ');
+				txt = txt.replace(/=([0-9A-Fa-f]{2})/g, (_m, h) =>
+					String.fromCharCode(parseInt(h, 16))
+				);
+				bytes = new Uint8Array([...txt].map((c) => c.charCodeAt(0)));
+			}
+			try {
+				return new TextDecoder(normalizeCharset(charset)).decode(bytes);
+			} catch {
+				return new TextDecoder().decode(bytes);
+			}
+		}
+	);
+}
+function normalizeCharset(cs: string): string {
+	cs = cs.toLowerCase();
+	return cs === 'utf8' ? 'utf-8' : cs;
+}
+function qpDecodeToBytes(s: string): Uint8Array {
+	s = s.replace(/=\r\n/g, '');
+	const out: number[] = [];
+	for (let i = 0; i < s.length; i++) {
+		const ch = s[i];
+		if (ch === '=' && i + 2 < s.length) {
+			const h = s.slice(i + 1, i + 3);
+			if (/^[0-9A-Fa-f]{2}$/.test(h)) {
+				out.push(parseInt(h, 16));
+				i += 2;
+				continue;
+			}
+		}
+		out.push(ch.charCodeAt(0));
+	}
+	return new Uint8Array(out);
+}
+function b64DecodeToBytes(s: string): Uint8Array {
+	const bin = atob(s.replace(/\s+/g, ''));
+	const out = new Uint8Array(bin.length);
+	for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+	return out;
+}
+function b64DecodeText(s: string): string {
+	const bytes = b64DecodeToBytes(s);
+	return new TextDecoder().decode(bytes);
+}
+function b64(s: string): string {
+	return btoa(s);
+}
+function stripQuotes(s: string): string {
+	const m = s.match(/^"(.*)"$/);
+	return m ? m[1] : s;
+}
+function getParam(h: string, name: string): string | null {
+	const re = new RegExp(`;\\s*${name}=([^;]+)`, 'i');
+	const m = h.match(re);
+	return m ? stripQuotes(m[1]) : null;
+}
+function pickTextPlainFromMultipart(
+	body: string,
+	boundary: string
+): { headers: Record<string, string>; content: string } | null {
+	const b = `--${boundary}`;
+	const end = `--${boundary}--`;
+	const lines = body.split('\r\n');
+	let cur: string[] = [];
+	const parts: string[] = [];
+	let inPart = false;
+	for (const line of lines) {
+		if (line === b) {
+			if (inPart && cur.length) parts.push(cur.join('\r\n'));
+			inPart = true;
+			cur = [];
+		} else if (line === end) {
+			if (inPart && cur.length) parts.push(cur.join('\r\n'));
+			inPart = false;
+			break;
+		} else if (inPart) {
+			cur.push(line);
+		}
+	}
+	if (inPart && cur.length) parts.push(cur.join('\r\n'));
+	for (const p of parts) {
+		const { headerRaw, bodyRaw } = splitHeaderBody(p);
+		const ph = parseHeaderLines(headerRaw);
+		const ct = (ph['content-type'] || 'text/plain').toLowerCase();
+		if (ct.startsWith('text/plain'))
+			return { headers: ph, content: bodyRaw };
+	}
+	return null;
+}
+function decodeBody(
+	cte: string | undefined,
+	charset: string | undefined,
+	content: string
+): string {
+	cte = (cte || '').toLowerCase();
+	const cs = normalizeCharset(charset || 'utf-8');
+	let bytes: Uint8Array;
+	if (cte === 'base64') bytes = b64DecodeToBytes(content);
+	else if (cte === 'quoted-printable') bytes = qpDecodeToBytes(content);
+	else bytes = new Uint8Array([...content].map((c) => c.charCodeAt(0)));
+	try {
+		return new TextDecoder(cs).decode(bytes);
+	} catch {
+		return new TextDecoder().decode(bytes);
+	}
+}
+export function parseMessage(
+	raw: string,
+	fallbackFrom: string,
+	fallbackRcpts: string[]
+): {
+	headers: Record<string, string>;
+	subject: string;
+	text?: string;
+	from: string;
+	to: string;
+} {
+	const { headerRaw, bodyRaw } = splitHeaderBody(raw);
+	const headers = parseHeaderLines(headerRaw);
+	const subject = headers['subject']
+		? decodeRfc2047(headers['subject'])
+		: '(no subject)';
+	const from = headers['from']
+		? decodeRfc2047(headers['from'])
+		: fallbackFrom;
+
+	const recipientParts: string[] = [];
+	for (const hdr of ['to', 'cc', 'bcc']) {
+		if (headers[hdr]) {
+			recipientParts.push(decodeRfc2047(headers[hdr]));
+		}
+	}
+	const to =
+		recipientParts.length > 0
+			? recipientParts.join(', ')
+			: fallbackRcpts.join(', ');
+
+	let text: string | undefined;
+	const ct = (headers['content-type'] || 'text/plain').toLowerCase();
+	if (ct.startsWith('multipart/')) {
+		const boundary = getParam(headers['content-type'], 'boundary');
+		if (boundary) {
+			const part = pickTextPlainFromMultipart(bodyRaw, boundary);
+			if (part) {
+				const pcte = (
+					part.headers['content-transfer-encoding'] || ''
+				).toLowerCase();
+				const pcharset =
+					getParam(part.headers['content-type'] || '', 'charset') ||
+					'utf-8';
+				text = decodeBody(pcte, pcharset, part.content);
+			}
+		}
+	} else if (ct.startsWith('text/plain')) {
+		const cte = (headers['content-transfer-encoding'] || '').toLowerCase();
+		const charset =
+			getParam(headers['content-type'] || '', 'charset') || 'utf-8';
+		text = decodeBody(cte, charset, bodyRaw);
+	} else {
+		text = bodyRaw;
+	}
+	return { headers, subject, text, from, to };
+}
+
+export function makeLoopbackPair(): [ByteDuplex, ByteDuplex] {
+	const a2b = new TransformStream<Uint8Array, Uint8Array>();
+	const b2a = new TransformStream<Uint8Array, Uint8Array>();
+	const a: ByteDuplex = { readable: b2a.readable, writable: a2b.writable };
+	const b: ByteDuplex = { readable: a2b.readable, writable: b2a.writable };
+	return [a, b];
+}
+
+function normalizeInitial(x?: string): string | null {
+	if (!x) return null;
+	const t = x.trim();
+	if (t === '' || t === '=') return null;
+	return t;
+}

--- a/packages/php-wasm/util/src/lib/websocket-shim.ts
+++ b/packages/php-wasm/util/src/lib/websocket-shim.ts
@@ -1,0 +1,117 @@
+/**
+ * Minimal WebSocket-shaped class used to intercept Emscripten's
+ * WebSocket-based TCP connections without opening a real network socket.
+ *
+ * Emscripten's networking layer treats sockets as WebSockets:
+ *   - In the browser it consumes the property-based API
+ *     (`onmessage`, `onclose`, etc.) and `addEventListener`.
+ *   - In Node.js (via the `ws` package) it consumes the EventEmitter-style
+ *     API (`on('message', (data, isBinary) => ...)`).
+ *
+ * This shim implements both surfaces so subclasses can be returned from a
+ * `websocket.decorator` hook in either runtime. Subclasses override `send`
+ * and `close` to wire up outbound bytes, and call the
+ * `emitOpen` / `emitMessage` / `emitClose` / `emitError` helpers to deliver
+ * inbound events. Those helpers and the `listeners` map are public because
+ * `websocket.decorator` returns an anonymous subclass expression, and
+ * TypeScript's TS4094 forbids exported class expressions whose base has
+ * private or protected members.
+ */
+export class WebSocketShim {
+	readonly CONNECTING = 0;
+	readonly OPEN = 1;
+	readonly CLOSING = 2;
+	readonly CLOSED = 3;
+
+	readyState = 0; // CONNECTING
+
+	url: string;
+	protocol = '';
+	binaryType: 'arraybuffer' | 'blob' = 'arraybuffer';
+	extensions = '';
+	bufferedAmount = 0;
+
+	onopen: ((e: any) => void) | null = null;
+	onmessage: ((e: any) => void) | null = null;
+	onclose: ((e: any) => void) | null = null;
+	onerror: ((e: any) => void) | null = null;
+
+	listeners = new Map<string, Set<(...args: any[]) => void>>();
+
+	constructor(url = '') {
+		this.url = url;
+	}
+
+	// Browser-style listener API
+	addEventListener(event: string, fn: (...args: any[]) => void) {
+		let set = this.listeners.get(event);
+		if (!set) {
+			set = new Set();
+			this.listeners.set(event, set);
+		}
+		set.add(fn);
+	}
+
+	removeEventListener(event: string, fn: (...args: any[]) => void) {
+		this.listeners.get(event)?.delete(fn);
+	}
+
+	// Node `ws`-style listener API
+	on(event: string, fn: (...args: any[]) => void) {
+		this.addEventListener(event, fn);
+	}
+
+	once(event: string, fn: (...args: any[]) => void) {
+		const wrapped = (...args: any[]) => {
+			this.removeEventListener(event, wrapped);
+			fn(...args);
+		};
+		this.addEventListener(event, wrapped);
+	}
+
+	removeListener(event: string, fn: (...args: any[]) => void) {
+		this.removeEventListener(event, fn);
+	}
+
+	emitOpen() {
+		this.readyState = this.OPEN;
+		this.onopen?.({});
+		const set = this.listeners.get('open');
+		if (set) for (const fn of set) fn({});
+	}
+
+	/**
+	 * Delivers an inbound message to consumers. Browser Emscripten reads
+	 * messages via the `onmessage` property and expects a MessageEvent-shaped
+	 * `{ data }` object, while Node Emscripten registers via `on('message')`
+	 * (the `ws` library convention) and expects `(data, isBinary)`.
+	 */
+	emitMessage(data: Uint8Array | ArrayBuffer | string) {
+		this.onmessage?.({ data });
+		const set = this.listeners.get('message');
+		if (!set) return;
+		const isBinary = typeof data !== 'string';
+		for (const fn of set) {
+			fn(data, isBinary);
+		}
+	}
+
+	emitClose() {
+		this.readyState = this.CLOSED;
+		this.onclose?.({});
+		const set = this.listeners.get('close');
+		if (set) for (const fn of set) fn({});
+	}
+
+	emitError(err: any) {
+		this.onerror?.(err);
+		const set = this.listeners.get('error');
+		if (set) for (const fn of set) fn(err);
+	}
+
+	// To be overridden by subclasses.
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	send(_data: ArrayBuffer | Uint8Array | string) {}
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	close(_code?: number, _reason?: string) {}
+}

--- a/packages/php-wasm/util/src/lib/websocket-shim.ts
+++ b/packages/php-wasm/util/src/lib/websocket-shim.ts
@@ -37,6 +37,7 @@ export class WebSocketShim {
 	onerror: ((e: any) => void) | null = null;
 
 	listeners = new Map<string, Set<(...args: any[]) => void>>();
+	nodeListeners = new Map<string, Set<(...args: any[]) => void>>();
 
 	constructor(url = '') {
 		this.url = url;
@@ -58,19 +59,24 @@ export class WebSocketShim {
 
 	// Node `ws`-style listener API
 	on(event: string, fn: (...args: any[]) => void) {
-		this.addEventListener(event, fn);
+		let set = this.nodeListeners.get(event);
+		if (!set) {
+			set = new Set();
+			this.nodeListeners.set(event, set);
+		}
+		set.add(fn);
 	}
 
 	once(event: string, fn: (...args: any[]) => void) {
 		const wrapped = (...args: any[]) => {
-			this.removeEventListener(event, wrapped);
+			this.removeListener(event, wrapped);
 			fn(...args);
 		};
-		this.addEventListener(event, wrapped);
+		this.on(event, wrapped);
 	}
 
 	removeListener(event: string, fn: (...args: any[]) => void) {
-		this.removeEventListener(event, fn);
+		this.nodeListeners.get(event)?.delete(fn);
 	}
 
 	emitOpen() {
@@ -78,6 +84,8 @@ export class WebSocketShim {
 		this.onopen?.({});
 		const set = this.listeners.get('open');
 		if (set) for (const fn of set) fn({});
+		const nodeSet = this.nodeListeners.get('open');
+		if (nodeSet) for (const fn of nodeSet) fn({});
 	}
 
 	/**
@@ -87,11 +95,15 @@ export class WebSocketShim {
 	 * (the `ws` library convention) and expects `(data, isBinary)`.
 	 */
 	emitMessage(data: Uint8Array | ArrayBuffer | string) {
-		this.onmessage?.({ data });
+		const event = { data };
+		this.onmessage?.(event);
 		const set = this.listeners.get('message');
-		if (!set) return;
+		if (set) for (const fn of set) fn(event);
+
+		const nodeSet = this.nodeListeners.get('message');
+		if (!nodeSet) return;
 		const isBinary = typeof data !== 'string';
-		for (const fn of set) {
+		for (const fn of nodeSet) {
 			fn(data, isBinary);
 		}
 	}
@@ -101,12 +113,16 @@ export class WebSocketShim {
 		this.onclose?.({});
 		const set = this.listeners.get('close');
 		if (set) for (const fn of set) fn({});
+		const nodeSet = this.nodeListeners.get('close');
+		if (nodeSet) for (const fn of nodeSet) fn({});
 	}
 
 	emitError(err: any) {
 		this.onerror?.(err);
 		const set = this.listeners.get('error');
 		if (set) for (const fn of set) fn(err);
+		const nodeSet = this.nodeListeners.get('error');
+		if (nodeSet) for (const fn of nodeSet) fn(err);
 	}
 
 	// To be overridden by subclasses.

--- a/packages/php-wasm/util/src/test/create-sendmail-handler.spec.ts
+++ b/packages/php-wasm/util/src/test/create-sendmail-handler.spec.ts
@@ -1,0 +1,38 @@
+import { createSendmailSpawnHandler } from '../lib/create-sendmail-handler';
+import type { CaughtMessage } from '../lib/smtp';
+
+const enc = new TextEncoder();
+
+describe('createSendmailSpawnHandler', () => {
+	it('reports rawSize in bytes and preserves non-ASCII raw text', async () => {
+		const messages: CaughtMessage[] = [];
+		const spawnHandler = createSendmailSpawnHandler((message) => {
+			messages.push(message);
+		});
+		const childProcess = spawnHandler('/usr/sbin/sendmail -t -i');
+		const spawned = new Promise<void>((resolve) => {
+			childProcess.on('spawn', () => resolve());
+		});
+		const exitCode = new Promise<number>((resolve) => {
+			childProcess.on('exit', resolve);
+		});
+
+		const raw =
+			'From: sender@test.com\n' +
+			'To: recipient@test.com\n' +
+			'Subject: UTF-8\n' +
+			'\n' +
+			'Caf\u00e9 \ud83d\ude80\n';
+		const normalizedRaw = raw.replace(/\r?\n/g, '\r\n');
+
+		await spawned;
+		childProcess.stdin.write(enc.encode(raw));
+		childProcess.stdin.end();
+
+		await expect(exitCode).resolves.toBe(0);
+		expect(messages).toHaveLength(1);
+		expect(messages[0].raw).toBe(normalizedRaw);
+		expect(messages[0].rawSize).toBe(enc.encode(normalizedRaw).byteLength);
+		expect(messages[0].rawSize).toBeGreaterThan(normalizedRaw.length);
+	});
+});

--- a/packages/php-wasm/util/src/test/websocket-shim.spec.ts
+++ b/packages/php-wasm/util/src/test/websocket-shim.spec.ts
@@ -1,0 +1,40 @@
+import { WebSocketShim } from '../lib/websocket-shim';
+
+describe('WebSocketShim', () => {
+	it('passes MessageEvent-shaped objects to browser message listeners', () => {
+		const ws = new WebSocketShim();
+		const message = new Uint8Array([1, 2, 3]);
+		const listener = vitest.fn();
+		const propertyHandler = vitest.fn();
+
+		ws.addEventListener('message', listener);
+		ws.onmessage = propertyHandler;
+		ws.emitMessage(message);
+
+		expect(listener).toHaveBeenCalledWith({ data: message });
+		expect(propertyHandler).toHaveBeenCalledWith({ data: message });
+	});
+
+	it('keeps Node-style message listeners on the ws callback shape', () => {
+		const ws = new WebSocketShim();
+		const message = new Uint8Array([1, 2, 3]);
+		const listener = vitest.fn();
+
+		ws.on('message', listener);
+		ws.emitMessage(message);
+
+		expect(listener).toHaveBeenCalledWith(message, true);
+	});
+
+	it('removes Node-style once listeners after the first event', () => {
+		const ws = new WebSocketShim();
+		const listener = vitest.fn();
+
+		ws.once('message', listener);
+		ws.emitMessage('first');
+		ws.emitMessage('second');
+
+		expect(listener).toHaveBeenCalledTimes(1);
+		expect(listener).toHaveBeenCalledWith('first', false);
+	});
+});

--- a/packages/php-wasm/web/src/lib/load-runtime.ts
+++ b/packages/php-wasm/web/src/lib/load-runtime.ts
@@ -8,7 +8,9 @@ import {
 	createLegacyPhpIniPreRunStep,
 	isLegacyPHPVersion,
 	loadPHPRuntime,
+	withSMTPSink,
 } from '@php-wasm/universal';
+import type { CaughtMessage } from '@php-wasm/util';
 import { getPHPLoaderModule } from './get-php-loader-module';
 import type { TCPOverFetchOptions } from './tcp-over-fetch-websocket';
 import { tcpOverFetchWebsocket } from './tcp-over-fetch-websocket';
@@ -33,6 +35,10 @@ export interface LoaderOptions {
 	 * @deprecated Use `extensions: ['intl']` instead.
 	 */
 	withIntl?: boolean;
+	withSMTPSink?: {
+		port: number;
+		onEmail: (message: CaughtMessage) => void;
+	};
 }
 
 /**
@@ -94,6 +100,12 @@ export async function loadWebRuntime(
 		emscriptenOptions = tcpOverFetchWebsocket(
 			emscriptenOptions,
 			loaderOptions.tcpOverFetch
+		);
+	}
+	if (loaderOptions.withSMTPSink) {
+		emscriptenOptions = withSMTPSink(
+			loaderOptions.withSMTPSink,
+			await emscriptenOptions
 		);
 	}
 


### PR DESCRIPTION
## Summary
- ports the current-trunk-safe parts of upstream WordPress/wordpress-playground#2585
- adds `withSMTPSink()` to capture direct SMTP traffic and sendmail-like `spawnProcess` calls
- wires the helper into Node and Web runtimes and adds SMTP protocol/unit coverage
- adds source-level PHP `mail()` build hooks, but does not include rebuilt PHP artifacts

## Status
This is intentionally a draft. Direct SMTP and explicit `/usr/sbin/sendmail` via `proc_open()` are covered and passing. The PHP `mail()` assertion is skipped until the PHP binaries are rebuilt with the source patch, ideally after deciding whether WordPress/wordpress-playground#3486 should land first for concurrent `popen()` handling.

## Verification
- `npx vitest run packages/php-wasm/util/src/lib/smtp.test.ts --config packages/php-wasm/util/vite.config.ts`
- `npx vitest run packages/php-wasm/node/src/test/php-smtp.spec.ts --config packages/php-wasm/node/vite.config.ts`
- `npx nx run-many -t lint --projects=php-wasm-util,php-wasm-universal,php-wasm-node,php-wasm-web --skip-nx-cache`
- `npx nx run-many -t typecheck --projects=php-wasm-universal,php-wasm-node,php-wasm-web --skip-nx-cache`
- `git diff --cached --check`

Tracked in fork issue #39.
