### PR TITLE
Buffer HTML service worker responses

### DIFF
--- a/packages/php-wasm/web-service-worker/src/lib/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/lib/utils.ts
@@ -141,17 +141,17 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 
 	let responseBody: ReadableStream<Uint8Array> | Uint8Array | null = null;
 	if (!isNullBodyCode) {
-		if (
-			phpResponse.bodyPort &&
-			!isHtmlContentType(phpResponse.headers['content-type'])
-		) {
+		const isHtmlResponse = isHtmlContentType(
+			phpResponse.headers['content-type']
+		);
+		if (phpResponse.bodyPort && (!isHtmlResponse || !phpResponse.bytes)) {
 			// Reconstruct the body ReadableStream from the MessagePort.
 			// We couldn't just transfer it directly as this kind of transfer
 			// doesn't seem to be supported between the document and the service worker.
 			responseBody = portToStream(phpResponse.bodyPort);
 		} else {
 			// Fallback: buffered response bytes
-			responseBody = phpResponse.bytes;
+			responseBody = phpResponse.bytes ?? new Uint8Array();
 		}
 	}
 

--- a/packages/php-wasm/web-service-worker/src/lib/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/lib/utils.ts
@@ -141,7 +141,10 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 
 	let responseBody: ReadableStream<Uint8Array> | Uint8Array | null = null;
 	if (!isNullBodyCode) {
-		if (phpResponse.bodyPort) {
+		if (
+			phpResponse.bodyPort &&
+			!isHtmlContentType(phpResponse.headers['content-type'])
+		) {
 			// Reconstruct the body ReadableStream from the MessagePort.
 			// We couldn't just transfer it directly as this kind of transfer
 			// doesn't seem to be supported between the document and the service worker.
@@ -320,6 +323,18 @@ export function getRequestHeaders(request: Request) {
 		headers[key] = value;
 	});
 	return headers;
+}
+
+export function isHtmlContentType(
+	contentType: string | string[] | undefined | null
+) {
+	const values = Array.isArray(contentType) ? contentType : [contentType];
+	return values.some((value) => {
+		if (!value) {
+			return false;
+		}
+		return value.split(';', 1)[0].trim().toLowerCase() === 'text/html';
+	});
 }
 
 /**

--- a/packages/php-wasm/web-service-worker/src/test/utils.spec.ts
+++ b/packages/php-wasm/web-service-worker/src/test/utils.spec.ts
@@ -51,9 +51,7 @@ describe('isHtmlContentType', () => {
 
 	it('accepts an array of content type values', () => {
 		expect(isHtmlContentType(['text/html'])).toBe(true);
-		expect(isHtmlContentType(['application/json', 'text/html'])).toBe(
-			true
-		);
+		expect(isHtmlContentType(['application/json', 'text/html'])).toBe(true);
 	});
 
 	it('returns false for non-HTML content types', () => {

--- a/packages/php-wasm/web-service-worker/src/test/utils.spec.ts
+++ b/packages/php-wasm/web-service-worker/src/test/utils.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	cloneRequest,
 	getRequestHeaders,
+	isHtmlContentType,
 	removeContentSecurityPolicyDirective,
 } from '../lib/utils';
 
@@ -31,6 +32,45 @@ describe('getRequestHeaders', () => {
 			'content-type': 'text/plain',
 			'x-wp-nonce': '123456',
 		});
+	});
+});
+
+describe('isHtmlContentType', () => {
+	it('detects text/html', () => {
+		expect(isHtmlContentType('text/html')).toBe(true);
+	});
+
+	it('detects text/html with parameters', () => {
+		expect(isHtmlContentType('text/html; charset=utf-8')).toBe(true);
+	});
+
+	it('is case-insensitive', () => {
+		expect(isHtmlContentType('Text/HTML')).toBe(true);
+		expect(isHtmlContentType('TEXT/HTML; charset=UTF-8')).toBe(true);
+	});
+
+	it('accepts an array of content type values', () => {
+		expect(isHtmlContentType(['text/html'])).toBe(true);
+		expect(isHtmlContentType(['application/json', 'text/html'])).toBe(
+			true
+		);
+	});
+
+	it('returns false for non-HTML content types', () => {
+		expect(isHtmlContentType('application/json')).toBe(false);
+		expect(isHtmlContentType('text/plain')).toBe(false);
+		expect(isHtmlContentType('image/png')).toBe(false);
+	});
+
+	it('returns false for empty values', () => {
+		expect(isHtmlContentType(undefined)).toBe(false);
+		expect(isHtmlContentType(null)).toBe(false);
+		expect(isHtmlContentType([])).toBe(false);
+	});
+
+	it('handles whitespace around the MIME type', () => {
+		expect(isHtmlContentType('  text/html  ')).toBe(true);
+		expect(isHtmlContentType('  text/html ; charset=utf-8')).toBe(true);
 	});
 });
 

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -1,5 +1,4 @@
 import type { MessageListener } from '@php-wasm/universal';
-import { streamToPort } from '@php-wasm/universal';
 import type { SyncProgressCallback } from '@php-wasm/web';
 import {
 	spawnPHPWorkerThread,
@@ -26,6 +25,7 @@ import type { FilesystemOperation } from '@php-wasm/fs-journal';
 import { logger } from '@php-wasm/logger';
 import { PhpWasmError } from '@php-wasm/util';
 import { responseTo } from '@php-wasm/web-service-worker';
+import { serializeStreamedResponseForServiceWorker } from './service-worker-response';
 
 // Select worker runtime (v1 or v2) based on query parameter
 // @ts-ignore
@@ -449,9 +449,6 @@ export async function bootPlaygroundRemote() {
 						const streamedResponse = await (
 							phpWorkerApi.requestStreamed as any
 						)(...args);
-						const httpStatusCode =
-							await streamedResponse.httpStatusCode;
-						const headers = await streamedResponse.headers;
 
 						/**
 						 * ReadableStreams are transferable, but cannot be
@@ -468,15 +465,18 @@ export async function bootPlaygroundRemote() {
 						 * * https://github.com/whatwg/streams/issues/1063
 						 * * https://github.com/whatwg/streams/issues/276
 						 * * https://groups.google.com/a/chromium.org/g/chromium-discuss/c/90Esr_dE6U4
+						 *
+						 * HTML responses are intentionally buffered instead
+						 * of bridged through a MessagePort so the browser can
+						 * inspect the document body during navigation.
 						 */
-						const bodyPort = streamToPort(streamedResponse.stdout);
+						const { response, transfer } =
+							await serializeStreamedResponseForServiceWorker(
+								streamedResponse
+							);
 						(event.source! as ServiceWorker).postMessage(
-							responseTo(event.data.requestId, {
-								httpStatusCode,
-								headers,
-								bodyPort,
-							}),
-							[bodyPort]
+							responseTo(event.data.requestId, response),
+							transfer
 						);
 					} else {
 						// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type

--- a/packages/playground/remote/src/lib/service-worker-response.spec.ts
+++ b/packages/playground/remote/src/lib/service-worker-response.spec.ts
@@ -1,0 +1,46 @@
+import { PHPResponse, StreamedPHPResponse } from '@php-wasm/universal';
+import { serializeStreamedResponseForServiceWorker } from './service-worker-response';
+
+const enc = new TextEncoder();
+
+describe('serializeStreamedResponseForServiceWorker', () => {
+	it('buffers HTML responses into bytes', async () => {
+		const bytes = enc.encode('<!doctype html><p>Hello</p>');
+		const streamedResponse = StreamedPHPResponse.fromPHPResponse(
+			new PHPResponse(
+				200,
+				{ 'content-type': ['text/html; charset=utf-8'] },
+				bytes
+			)
+		);
+
+		const { response, transfer } =
+			await serializeStreamedResponseForServiceWorker(streamedResponse);
+
+		expect(response.httpStatusCode).toBe(200);
+		expect(response.headers['content-type']).toEqual([
+			'text/html; charset=utf-8',
+		]);
+		expect(response.bytes).toEqual(bytes);
+		expect(response.bodyPort).toBeUndefined();
+		expect(transfer).toEqual([bytes.buffer]);
+	});
+
+	it('keeps non-HTML responses streamed through a MessagePort', async () => {
+		const streamedResponse = StreamedPHPResponse.fromPHPResponse(
+			new PHPResponse(
+				200,
+				{ 'content-type': ['application/octet-stream'] },
+				enc.encode('binary')
+			)
+		);
+
+		const { response, transfer } =
+			await serializeStreamedResponseForServiceWorker(streamedResponse);
+
+		expect(response.bytes).toBeUndefined();
+		expect(response.bodyPort).toBeDefined();
+		expect(transfer).toEqual([response.bodyPort]);
+		response.bodyPort?.close();
+	});
+});

--- a/packages/playground/remote/src/lib/service-worker-response.ts
+++ b/packages/playground/remote/src/lib/service-worker-response.ts
@@ -14,6 +14,14 @@ export type SerializedServiceWorkerPHPResponse = {
 	transfer: Transferable[];
 };
 
+/**
+ * Serializes a streamed PHP response for transfer to the service worker.
+ *
+ * The remote iframe cannot transfer a ReadableStream directly, so most
+ * responses are bridged through a MessagePort. HTML navigations are buffered
+ * instead because browsers expect the navigation document body to be complete
+ * when the service worker resolves the fetch response.
+ */
 export async function serializeStreamedResponseForServiceWorker(
 	streamedResponse: StreamedPHPResponse
 ): Promise<SerializedServiceWorkerPHPResponse> {
@@ -21,6 +29,8 @@ export async function serializeStreamedResponseForServiceWorker(
 	const headers = await streamedResponse.headers;
 
 	if (isHtmlContentType(headers['content-type'])) {
+		// Buffer HTML documents so navigation requests receive a complete body
+		// instead of a MessagePort-backed stream.
 		const bytes = await streamedResponse.stdoutBytes;
 		const transfer =
 			bytes.byteLength > 0 && bytes.buffer instanceof ArrayBuffer
@@ -36,6 +46,8 @@ export async function serializeStreamedResponseForServiceWorker(
 		};
 	}
 
+	// Keep non-HTML responses streamed to avoid buffering large assets or
+	// binary downloads in memory before the service worker can respond.
 	const bodyPort = streamToPort(streamedResponse.stdout);
 	return {
 		response: {

--- a/packages/playground/remote/src/lib/service-worker-response.ts
+++ b/packages/playground/remote/src/lib/service-worker-response.ts
@@ -1,0 +1,48 @@
+import type { StreamedPHPResponse } from '@php-wasm/universal';
+import { streamToPort } from '@php-wasm/universal';
+import { isHtmlContentType } from '@php-wasm/web-service-worker';
+
+export type ServiceWorkerPHPResponse = {
+	httpStatusCode: number;
+	headers: Record<string, string[]>;
+	bodyPort?: MessagePort;
+	bytes?: Uint8Array;
+};
+
+export type SerializedServiceWorkerPHPResponse = {
+	response: ServiceWorkerPHPResponse;
+	transfer: Transferable[];
+};
+
+export async function serializeStreamedResponseForServiceWorker(
+	streamedResponse: StreamedPHPResponse
+): Promise<SerializedServiceWorkerPHPResponse> {
+	const httpStatusCode = await streamedResponse.httpStatusCode;
+	const headers = await streamedResponse.headers;
+
+	if (isHtmlContentType(headers['content-type'])) {
+		const bytes = await streamedResponse.stdoutBytes;
+		const transfer =
+			bytes.byteLength > 0 && bytes.buffer instanceof ArrayBuffer
+				? [bytes.buffer]
+				: [];
+		return {
+			response: {
+				httpStatusCode,
+				headers,
+				bytes,
+			},
+			transfer,
+		};
+	}
+
+	const bodyPort = streamToPort(streamedResponse.stdout);
+	return {
+		response: {
+			httpStatusCode,
+			headers,
+			bodyPort,
+		},
+		transfer: [bodyPort],
+	};
+}

--- a/packages/playground/remote/src/lib/service-worker-response.ts
+++ b/packages/playground/remote/src/lib/service-worker-response.ts
@@ -17,10 +17,17 @@ export type SerializedServiceWorkerPHPResponse = {
 /**
  * Serializes a streamed PHP response for transfer to the service worker.
  *
- * The remote iframe cannot transfer a ReadableStream directly, so most
- * responses are bridged through a MessagePort. HTML navigations are buffered
- * instead because browsers expect the navigation document body to be complete
- * when the service worker resolves the fetch response.
+ * Most responses are kept as streams, just wrapped in a MessagePort
+ * since ReadableStream is not directly transferrable to the remote.html iframe.
+ *
+ * HTML responses, however, are buffered. Otherwise the browser may assume
+ * the HTML elements are intentionally provided over time and apply a
+ * confusing "gradual fade-in" effect when view transitions are enabled.
+ * It's bad UX. A single all-or-nothing transition feels a lot better.
+ * Therefore, we wait until the entire HTML body is available and expose
+ * it all at once.
+ *
+ * @see https://github.com/WordPress/wordpress-playground/issues/3436
  */
 export async function serializeStreamedResponseForServiceWorker(
 	streamedResponse: StreamedPHPResponse
@@ -29,8 +36,7 @@ export async function serializeStreamedResponseForServiceWorker(
 	const headers = await streamedResponse.headers;
 
 	if (isHtmlContentType(headers['content-type'])) {
-		// Buffer HTML documents so navigation requests receive a complete body
-		// instead of a MessagePort-backed stream.
+		// Buffer HTML responses for a nice full-page view transition.
 		const bytes = await streamedResponse.stdoutBytes;
 		const transfer =
 			bytes.byteLength > 0 && bytes.buffer instanceof ArrayBuffer


### PR DESCRIPTION
## Summary
- refreshes the current-trunk version of upstream WordPress/wordpress-playground#3385
- keeps streamed responses for non-HTML content
- buffers `text/html` responses by falling back to the already-buffered response bytes
- adds content-type detection tests for plain, parameterized, case-varied, and array header values

## Verification
- `git diff --check origin/trunk...HEAD`
- `npx vitest run packages/php-wasm/web-service-worker/src/test/utils.spec.ts --config packages/php-wasm/web-service-worker/vite.config.ts`
- `npx vitest run packages/playground/remote/src/lib/service-worker-response.spec.ts --config packages/playground/remote/vite.config.ts`
- GitHub `Lint and typecheck` is passing on head `6db14dadd6089c7ce17839c5d79b1a8082c318b4`

## Browser Smoke
Tried to verify the `/wp-admin/` HTML navigation path locally with Chromium against `npx nx run playground-website:dev`:
- `xvfb-run`/`Xvfb` are not installed in this environment, so the smoke used headless system Chromium.
- The iframe stayed at an empty `<body></body>` until timeout.
- The dev server logged the same Vite optimized-dependency missing-file warning seen in the shared Personal WP failures.

This does not identify a PR-specific HTML-buffering regression, but it means the manual browser confirmation remains open until a stable local/CI browser environment can render the WordPress iframe.

Tracked in fork issue #40.