### PR TITLE
Add built package bundler smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,6 +413,8 @@ jobs:
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 22
+            - name: Install Playwright Browsers
+              run: npx --yes playwright@1.55.1 install --with-deps chromium
             - name: Build packages, start local registry, and run integration tests
               run: packages/playground/test-built-npm-packages/run-tests.sh
 

--- a/packages/php-wasm/node/build.js
+++ b/packages/php-wasm/node/build.js
@@ -75,7 +75,7 @@ async function build() {
 			'ws',
 			'fs',
 			'path',
-			'fs-ext',
+			'fs-ext-extra-prebuilt',
 		],
 		supported: {
 			'dynamic-import': true,

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/.gitignore
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+bundler-tests/dist

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/entry-node-dynamic-import.cjs
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/entry-node-dynamic-import.cjs
@@ -1,0 +1,24 @@
+/**
+ * Entry point for testing Node.js bundle with dynamic import() in CommonJS.
+ * This tests that the packages can be dynamically imported in a CommonJS context.
+ */
+
+// Simple smoke test that verifies dynamic imports work in CJS
+async function smokeTest() {
+	const { PHP } = await import('@php-wasm/universal');
+	const { loadNodeRuntime } = await import('@php-wasm/node');
+
+	if (typeof PHP !== 'function') {
+		throw new Error('PHP is not a function');
+	}
+	if (typeof loadNodeRuntime !== 'function') {
+		throw new Error('loadNodeRuntime is not a function');
+	}
+	console.log(
+		'[node-dynamic-import-cjs] Smoke test passed: PHP and loadNodeRuntime are available via dynamic import()'
+	);
+	return true;
+}
+
+// Export for external use
+module.exports = { smokeTest };

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/entry-node-require.cjs
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/entry-node-require.cjs
@@ -1,0 +1,23 @@
+/**
+ * Entry point for testing Node.js bundle with CommonJS require().
+ * This tests that the packages can be required in a CommonJS context.
+ */
+const { PHP } = require('@php-wasm/universal');
+const { loadNodeRuntime } = require('@php-wasm/node');
+
+// Simple smoke test that verifies the requires resolved correctly
+function smokeTest() {
+	if (typeof PHP !== 'function') {
+		throw new Error('PHP is not a function');
+	}
+	if (typeof loadNodeRuntime !== 'function') {
+		throw new Error('loadNodeRuntime is not a function');
+	}
+	console.log(
+		'[node-require] Smoke test passed: PHP and loadNodeRuntime are available via require()'
+	);
+	return true;
+}
+
+// Export for use in smoke tests
+module.exports = { PHP, loadNodeRuntime, smokeTest };

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/entry-web-require.cjs
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/entry-web-require.cjs
@@ -1,0 +1,27 @@
+/**
+ * Entry point for testing browser bundle with CommonJS require().
+ * This tests that web packages can be required in a CommonJS context
+ * and then bundled for the browser.
+ */
+const { PHP } = require('@php-wasm/universal');
+const { loadWebRuntime } = require('@php-wasm/web');
+
+// Export for use in smoke tests
+module.exports = { PHP, loadWebRuntime };
+
+// Simple smoke test that verifies the requires resolved correctly
+function smokeTest() {
+	if (typeof PHP !== 'function') {
+		throw new Error('PHP is not a function');
+	}
+	if (typeof loadWebRuntime !== 'function') {
+		throw new Error('loadWebRuntime is not a function');
+	}
+	console.log(
+		'[web-require] Smoke test passed: PHP and loadWebRuntime are available via require()'
+	);
+	return true;
+}
+
+// Auto-run smoke test when loaded
+smokeTest();

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/run-bundler-tests.cjs
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/run-bundler-tests.cjs
@@ -1,0 +1,333 @@
+/**
+ * Runs bundler tests to verify that @php-wasm/* and @wp-playground/* packages
+ * can be bundled with Vite for both browser and Node.js targets in a CommonJS context.
+ *
+ * This test:
+ * 1. Builds each entry point with Vite
+ * 2. Loads the bundled output (Node bundles via require, web bundles via Playwright)
+ * 3. Verifies it doesn't error out
+ */
+const { spawn } = require('child_process');
+const { mkdir, readdir, writeFile } = require('fs/promises');
+const { join } = require('path');
+const { pathToFileURL } = require('url');
+const { chromium } = require('playwright');
+
+const green = (text) => `\x1b[32m${text}\x1b[0m`;
+const red = (text) => `\x1b[31m${text}\x1b[0m`;
+
+async function runCommand(command, args, cwd) {
+	return new Promise((resolve) => {
+		const proc = spawn(command, args, {
+			cwd,
+			stdio: ['ignore', 'pipe', 'pipe'],
+			shell: true,
+		});
+
+		let stdout = '';
+		let stderr = '';
+
+		proc.stdout.on('data', (data) => {
+			stdout += data.toString();
+		});
+
+		proc.stderr.on('data', (data) => {
+			stderr += data.toString();
+		});
+
+		proc.on('close', (code) => {
+			resolve({ code: code ?? 1, stdout, stderr });
+		});
+	});
+}
+
+async function buildBundle(configFile) {
+	console.log(`  Building with ${configFile}...`);
+	const result = await runCommand(
+		'npx',
+		['vite', 'build', '--config', configFile],
+		__dirname
+	);
+
+	if (result.code !== 0) {
+		console.error(`  Build failed:`);
+		console.error(result.stderr || result.stdout);
+		return false;
+	}
+
+	console.log(`  Build successful`);
+	return true;
+}
+
+async function loadNodeBundle(bundlePath) {
+	console.log(`  Loading bundle: ${bundlePath}...`);
+	try {
+		const bundle = require(bundlePath);
+		if (typeof bundle.smokeTest === 'function') {
+			await bundle.smokeTest();
+		}
+		console.log(`  Bundle loaded successfully`);
+		return true;
+	} catch (error) {
+		console.error(`  Failed to load bundle:`, error);
+		return false;
+	}
+}
+
+async function loadWebBundleInBrowser(distDir, jsFile) {
+	console.log(`  Loading web bundle in browser: ${jsFile}...`);
+
+	// Create a simple HTML file that loads the bundle
+	const htmlContent = `<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>Bundle Test</title>
+</head>
+<body>
+	<script type="module">
+		window.testErrors = [];
+		window.testLogs = [];
+		window.smokeTestPassed = false;
+
+		window.onerror = (msg, url, line, col, error) => {
+			window.testErrors.push({ msg, url, line, col, error: error?.toString() });
+		};
+
+		const originalConsoleLog = console.log;
+		console.log = (...args) => {
+			window.testLogs.push(args.join(' '));
+			originalConsoleLog.apply(console, args);
+		};
+
+		const originalConsoleError = console.error;
+		console.error = (...args) => {
+			window.testErrors.push({ msg: args.join(' ') });
+			originalConsoleError.apply(console, args);
+		};
+	</script>
+	<script type="module" src="./${jsFile}"></script>
+	<script type="module">
+		// Check if smoke test passed by looking for the log message
+		setTimeout(() => {
+			window.smokeTestPassed = window.testLogs.some(log =>
+				log.includes('Smoke test passed')
+			);
+			window.testComplete = true;
+		}, 1000);
+	</script>
+</body>
+</html>`;
+
+	const htmlPath = join(distDir, 'test.html');
+	await writeFile(htmlPath, htmlContent);
+
+	let browser;
+	try {
+		browser = await chromium.launch({
+			headless: true,
+			args: [
+				'--no-sandbox',
+				'--disable-setuid-sandbox',
+				'--allow-file-access-from-files',
+				'--disable-web-security',
+			],
+		});
+		const page = await browser.newPage();
+
+		// Collect page errors
+		const pageErrors = [];
+		page.on('pageerror', (error) => {
+			pageErrors.push(error.toString());
+		});
+		page.on('console', (msg) => {
+			if (msg.type() === 'error') {
+				pageErrors.push(msg.text());
+			}
+		});
+
+		// Navigate to the test page
+		await page.goto(pathToFileURL(htmlPath).href, {
+			waitUntil: 'networkidle',
+		});
+
+		// Wait for test to complete
+		await page.waitForFunction('window.testComplete === true', {
+			timeout: 10000,
+		});
+
+		// Check results
+		const results = await page.evaluate(() => ({
+			errors: window.testErrors,
+			logs: window.testLogs,
+			smokeTestPassed: window.smokeTestPassed,
+		}));
+
+		if (pageErrors.length > 0) {
+			return {
+				success: false,
+				error: `Page errors: ${pageErrors.join(', ')}`,
+			};
+		}
+
+		if (results.errors && results.errors.length > 0) {
+			return {
+				success: false,
+				error: `JS errors: ${JSON.stringify(results.errors)}`,
+			};
+		}
+
+		if (!results.smokeTestPassed) {
+			return {
+				success: false,
+				error: `Smoke test did not pass. Logs: ${results.logs?.join(', ') || 'none'}`,
+			};
+		}
+
+		console.log(`  Web bundle loaded successfully in browser`);
+		return { success: true };
+	} catch (error) {
+		return {
+			success: false,
+			error: `Playwright error: ${error}`,
+		};
+	} finally {
+		if (browser) {
+			await browser.close();
+		}
+	}
+}
+
+async function runTest(name, configFile, outputDir, target) {
+	console.log(`\n=== ${name} ===`);
+
+	// Build the bundle
+	const buildSuccess = await buildBundle(configFile);
+	if (!buildSuccess) {
+		return { name, success: false, error: 'Build failed' };
+	}
+
+	// For Node.js bundles, try to load them
+	if (target === 'node') {
+		const distDir = join(__dirname, outputDir);
+		try {
+			const files = await readdir(distDir);
+			const jsFile = files.find(
+				(f) => f.endsWith('.cjs') || f.endsWith('.js')
+			);
+			if (!jsFile) {
+				return {
+					name,
+					success: false,
+					error: 'No JS file found in output',
+				};
+			}
+
+			const bundlePath = join(distDir, jsFile);
+			const loadSuccess = await loadNodeBundle(bundlePath);
+			if (!loadSuccess) {
+				return { name, success: false, error: 'Failed to load bundle' };
+			}
+		} catch (error) {
+			return {
+				name,
+				success: false,
+				error: `Failed to read output directory: ${error}`,
+			};
+		}
+	}
+
+	// For web bundles, load them in a browser using Playwright
+	if (target === 'web') {
+		const distDir = join(__dirname, outputDir);
+		try {
+			const files = await readdir(distDir);
+			// Look for .js or .mjs files (Vite may use either depending on package type)
+			const jsFile = files.find(
+				(f) => f.endsWith('.js') || f.endsWith('.mjs')
+			);
+			if (!jsFile) {
+				return {
+					name,
+					success: false,
+					error: `No JS file found in output. Files: ${files.join(', ')}`,
+				};
+			}
+
+			const browserResult = await loadWebBundleInBrowser(distDir, jsFile);
+			if (!browserResult.success) {
+				return { name, success: false, error: browserResult.error };
+			}
+		} catch (error) {
+			return {
+				name,
+				success: false,
+				error: `Failed to test web bundle: ${error}`,
+			};
+		}
+	}
+
+	return { name, success: true };
+}
+
+async function main() {
+	console.log('=== Bundler Tests (CommonJS) ===');
+	console.log(
+		'Testing that @php-wasm/* packages can be bundled with Vite from CommonJS\n'
+	);
+
+	await mkdir(join(__dirname, 'dist'), { recursive: true });
+
+	const results = [];
+
+	// Test 1: Node bundle with require()
+	results.push(
+		await runTest(
+			'Node Bundle (require)',
+			'vite.config.node-require.mjs',
+			'dist/node-require',
+			'node'
+		)
+	);
+
+	// Test 2: Node bundle with dynamic import() in CJS
+	results.push(
+		await runTest(
+			'Node Bundle (dynamic import in CJS)',
+			'vite.config.node-dynamic.mjs',
+			'dist/node-dynamic',
+			'node'
+		)
+	);
+
+	// Test 3: Web bundle from CJS require()
+	results.push(
+		await runTest(
+			'Web Bundle (require)',
+			'vite.config.web-require.mjs',
+			'dist/web-require',
+			'web'
+		)
+	);
+
+	// Print summary
+	console.log('\n=== Results ===');
+	let allPassed = true;
+	for (const result of results) {
+		if (result.success) {
+			console.log(green(`✓ ${result.name}`));
+		} else {
+			console.log(red(`✗ ${result.name}: ${result.error}`));
+			allPassed = false;
+		}
+	}
+
+	if (allPassed) {
+		console.log(green('\nAll bundler tests passed!'));
+	} else {
+		console.log(red('\nSome bundler tests failed!'));
+		process.exit(1);
+	}
+}
+
+main();

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/vite.config.node-dynamic.mjs
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/vite.config.node-dynamic.mjs
@@ -22,6 +22,7 @@ export default defineConfig({
 			external: [
 				...builtinModules,
 				...builtinModules.map((m) => `node:${m}`),
+				'fs-ext-extra-prebuilt',
 				/\.wasm$/,
 				/\.so$/,
 				/\.dat$/,

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/vite.config.node-dynamic.mjs
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/vite.config.node-dynamic.mjs
@@ -1,0 +1,34 @@
+/**
+ * Vite config for bundling node packages with dynamic import() in CommonJS.
+ * Node.js builtins and binary assets are externalized.
+ */
+import { defineConfig } from 'vite';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { builtinModules } from 'module';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+	build: {
+		outDir: 'dist/node-dynamic',
+		lib: {
+			entry: resolve(__dirname, 'entry-node-dynamic-import.cjs'),
+			name: 'PlaygroundNodeDynamicCJS',
+			fileName: 'bundle-node-dynamic-import',
+			formats: ['cjs'],
+		},
+		rollupOptions: {
+			external: [
+				...builtinModules,
+				...builtinModules.map((m) => `node:${m}`),
+				/\.wasm$/,
+				/\.so$/,
+				/\.dat$/,
+			],
+		},
+		target: 'node18',
+		minify: false,
+		sourcemap: true,
+	},
+});

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/vite.config.node-require.mjs
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/vite.config.node-require.mjs
@@ -22,6 +22,7 @@ export default defineConfig({
 			external: [
 				...builtinModules,
 				...builtinModules.map((m) => `node:${m}`),
+				'fs-ext-extra-prebuilt',
 				/\.wasm$/,
 				/\.so$/,
 				/\.dat$/,

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/vite.config.node-require.mjs
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/vite.config.node-require.mjs
@@ -1,0 +1,34 @@
+/**
+ * Vite config for bundling node packages with CommonJS require().
+ * Node.js builtins and binary assets are externalized.
+ */
+import { defineConfig } from 'vite';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { builtinModules } from 'module';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+	build: {
+		outDir: 'dist/node-require',
+		lib: {
+			entry: resolve(__dirname, 'entry-node-require.cjs'),
+			name: 'PlaygroundNodeCJS',
+			fileName: 'bundle-node-require',
+			formats: ['cjs'],
+		},
+		rollupOptions: {
+			external: [
+				...builtinModules,
+				...builtinModules.map((m) => `node:${m}`),
+				/\.wasm$/,
+				/\.so$/,
+				/\.dat$/,
+			],
+		},
+		target: 'node18',
+		minify: false,
+		sourcemap: true,
+	},
+});

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/vite.config.web-require.mjs
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/vite.config.web-require.mjs
@@ -1,0 +1,27 @@
+/**
+ * Vite config for bundling web packages with CommonJS require() for browser.
+ * Binary assets are externalized - they're loaded at runtime.
+ */
+import { defineConfig } from 'vite';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+	build: {
+		outDir: 'dist/web-require',
+		lib: {
+			entry: resolve(__dirname, 'entry-web-require.cjs'),
+			name: 'PlaygroundWebCJS',
+			fileName: 'bundle-web-require',
+			formats: ['es'],
+		},
+		rollupOptions: {
+			external: [/\.wasm$/, /\.so$/, /\.dat$/],
+		},
+		target: 'esnext',
+		minify: false,
+		sourcemap: true,
+	},
+});

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/package.json
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/package.json
@@ -15,14 +15,20 @@
 	"type": "commonjs",
 	"main": "index.js",
 	"scripts": {
-		"test": "jest"
+		"test": "jest",
+		"test:bundle": "node bundler-tests/run-bundler-tests.cjs"
 	},
 	"devDependencies": {
+		"@php-wasm/node": "^1.2.3",
+		"@php-wasm/universal": "^1.2.3",
+		"@php-wasm/web": "^1.2.3",
 		"@types/node": "^22.14.1",
-		"@wp-playground/cli": "^1.2.3",
 		"@types/jest": "^29.5.14",
+		"@wp-playground/cli": "^1.2.3",
 		"jest": "^29.7.0",
+		"playwright": "1.55.1",
 		"ts-jest": "^29.3.2",
-		"typescript": "^5.3.0"
+		"typescript": "^5.3.0",
+		"vite": "^5.0.0"
 	}
 }

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/run-with-local-packages.sh
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/run-with-local-packages.sh
@@ -24,3 +24,4 @@ npm install
 
 # Run tests
 npm run test
+npm run test:bundle

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/.gitignore
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+bundler-tests/dist

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/entry-node-dynamic-imports.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/entry-node-dynamic-imports.ts
@@ -1,0 +1,21 @@
+/**
+ * Entry point for testing Node.js bundle with dynamic ESM imports.
+ * This tests that the packages can be dynamically imported at runtime.
+ */
+
+// Simple smoke test that verifies dynamic imports work
+export async function smokeTest(): Promise<boolean> {
+	const { PHP } = await import('@php-wasm/universal');
+	const { loadNodeRuntime } = await import('@php-wasm/node');
+
+	if (typeof PHP !== 'function') {
+		throw new Error('PHP is not a function');
+	}
+	if (typeof loadNodeRuntime !== 'function') {
+		throw new Error('loadNodeRuntime is not a function');
+	}
+	console.log(
+		'[node-dynamic-imports] Smoke test passed: PHP and loadNodeRuntime are available via dynamic import'
+	);
+	return true;
+}

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/entry-node-static-imports.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/entry-node-static-imports.ts
@@ -1,0 +1,24 @@
+/**
+ * Entry point for testing Node.js bundle with static ESM imports.
+ * This file imports @php-wasm/node and @php-wasm/universal which are
+ * the packages intended for Node.js use.
+ */
+import { PHP } from '@php-wasm/universal';
+import { loadNodeRuntime } from '@php-wasm/node';
+
+// Export for use in smoke tests
+export { PHP, loadNodeRuntime };
+
+// Simple smoke test that verifies the imports resolved correctly
+export function smokeTest(): boolean {
+	if (typeof PHP !== 'function') {
+		throw new Error('PHP is not a function');
+	}
+	if (typeof loadNodeRuntime !== 'function') {
+		throw new Error('loadNodeRuntime is not a function');
+	}
+	console.log(
+		'[node-static-imports] Smoke test passed: PHP and loadNodeRuntime are available'
+	);
+	return true;
+}

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/entry-web-static-imports.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/entry-web-static-imports.ts
@@ -1,0 +1,27 @@
+/**
+ * Entry point for testing browser bundle with static ESM imports.
+ * This file imports @php-wasm/web and @php-wasm/universal which are
+ * the packages intended for browser use.
+ */
+import { PHP } from '@php-wasm/universal';
+import { loadWebRuntime } from '@php-wasm/web';
+
+// Export for use in smoke tests
+export { PHP, loadWebRuntime };
+
+// Simple smoke test that verifies the imports resolved correctly
+export function smokeTest(): boolean {
+	if (typeof PHP !== 'function') {
+		throw new Error('PHP is not a function');
+	}
+	if (typeof loadWebRuntime !== 'function') {
+		throw new Error('loadWebRuntime is not a function');
+	}
+	console.log(
+		'[web-static-imports] Smoke test passed: PHP and loadWebRuntime are available'
+	);
+	return true;
+}
+
+// Auto-run smoke test when loaded
+smokeTest();

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/run-bundler-tests.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/run-bundler-tests.ts
@@ -1,0 +1,356 @@
+/**
+ * Runs bundler tests to verify that @php-wasm/* and @wp-playground/* packages
+ * can be bundled with Vite for both browser and Node.js targets.
+ *
+ * This test:
+ * 1. Builds each entry point with Vite
+ * 2. Loads the bundled output (Node bundles via import, web bundles via Playwright)
+ * 3. Verifies it doesn't error out
+ */
+import { spawn } from 'child_process';
+import { readdir, writeFile, mkdir } from 'fs/promises';
+import { join, dirname } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+import { chromium } from 'playwright';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+interface TestResult {
+	name: string;
+	success: boolean;
+	error?: string;
+}
+
+function green(text: string): string {
+	return `\x1b[32m${text}\x1b[0m`;
+}
+
+function red(text: string): string {
+	return `\x1b[31m${text}\x1b[0m`;
+}
+
+async function runCommand(
+	command: string,
+	args: string[],
+	cwd: string
+): Promise<{ code: number; stdout: string; stderr: string }> {
+	return new Promise((resolve) => {
+		const proc = spawn(command, args, {
+			cwd,
+			stdio: ['ignore', 'pipe', 'pipe'],
+			shell: true,
+		});
+
+		let stdout = '';
+		let stderr = '';
+
+		proc.stdout.on('data', (data) => {
+			stdout += data.toString();
+		});
+
+		proc.stderr.on('data', (data) => {
+			stderr += data.toString();
+		});
+
+		proc.on('close', (code) => {
+			resolve({ code: code ?? 1, stdout, stderr });
+		});
+	});
+}
+
+async function buildBundle(configFile: string): Promise<boolean> {
+	console.log(`  Building with ${configFile}...`);
+	const result = await runCommand(
+		'npx',
+		['vite', 'build', '--config', configFile],
+		__dirname
+	);
+
+	if (result.code !== 0) {
+		console.error(`  Build failed:`);
+		console.error(result.stderr || result.stdout);
+		return false;
+	}
+
+	console.log(`  Build successful`);
+	return true;
+}
+
+async function loadNodeBundle(bundlePath: string): Promise<boolean> {
+	console.log(`  Loading bundle: ${bundlePath}...`);
+	try {
+		const module = await import(bundlePath);
+		if (typeof module.smokeTest === 'function') {
+			await module.smokeTest();
+		}
+		console.log(`  Bundle loaded successfully`);
+		return true;
+	} catch (error) {
+		console.error(`  Failed to load bundle:`, error);
+		return false;
+	}
+}
+
+async function loadWebBundleInBrowser(
+	distDir: string,
+	jsFile: string
+): Promise<{ success: boolean; error?: string }> {
+	console.log(`  Loading web bundle in browser: ${jsFile}...`);
+
+	// Create a simple HTML file that loads the bundle
+	const htmlContent = `<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>Bundle Test</title>
+</head>
+<body>
+	<script type="module">
+		window.testErrors = [];
+		window.testLogs = [];
+		window.smokeTestPassed = false;
+
+		window.onerror = (msg, url, line, col, error) => {
+			window.testErrors.push({ msg, url, line, col, error: error?.toString() });
+		};
+
+		const originalConsoleLog = console.log;
+		console.log = (...args) => {
+			window.testLogs.push(args.join(' '));
+			originalConsoleLog.apply(console, args);
+		};
+
+		const originalConsoleError = console.error;
+		console.error = (...args) => {
+			window.testErrors.push({ msg: args.join(' ') });
+			originalConsoleError.apply(console, args);
+		};
+	</script>
+	<script type="module" src="./${jsFile}"></script>
+	<script type="module">
+		// Check if smoke test passed by looking for the log message
+		setTimeout(() => {
+			window.smokeTestPassed = window.testLogs.some(log =>
+				log.includes('Smoke test passed')
+			);
+			window.testComplete = true;
+		}, 1000);
+	</script>
+</body>
+</html>`;
+
+	const htmlPath = join(distDir, 'test.html');
+	await writeFile(htmlPath, htmlContent);
+
+	let browser;
+	try {
+		browser = await chromium.launch({
+			headless: true,
+			args: [
+				'--no-sandbox',
+				'--disable-setuid-sandbox',
+				'--allow-file-access-from-files',
+				'--disable-web-security',
+			],
+		});
+		const page = await browser.newPage();
+
+		// Collect page errors
+		const pageErrors: string[] = [];
+		page.on('pageerror', (error) => {
+			pageErrors.push(error.toString());
+		});
+		page.on('console', (msg) => {
+			if (msg.type() === 'error') {
+				pageErrors.push(msg.text());
+			}
+		});
+
+		// Navigate to the test page
+		await page.goto(pathToFileURL(htmlPath).href, {
+			waitUntil: 'networkidle',
+		});
+
+		// Wait for test to complete
+		await page.waitForFunction('window.testComplete === true', {
+			timeout: 10000,
+		});
+
+		// Check results
+		const results = await page.evaluate(() => ({
+			errors: (window as any).testErrors,
+			logs: (window as any).testLogs,
+			smokeTestPassed: (window as any).smokeTestPassed,
+		}));
+
+		if (pageErrors.length > 0) {
+			return {
+				success: false,
+				error: `Page errors: ${pageErrors.join(', ')}`,
+			};
+		}
+
+		if (results.errors && results.errors.length > 0) {
+			return {
+				success: false,
+				error: `JS errors: ${JSON.stringify(results.errors)}`,
+			};
+		}
+
+		if (!results.smokeTestPassed) {
+			return {
+				success: false,
+				error: `Smoke test did not pass. Logs: ${results.logs?.join(', ') || 'none'}`,
+			};
+		}
+
+		console.log(`  Web bundle loaded successfully in browser`);
+		return { success: true };
+	} catch (error) {
+		return {
+			success: false,
+			error: `Playwright error: ${error}`,
+		};
+	} finally {
+		if (browser) {
+			await browser.close();
+		}
+	}
+}
+
+async function runTest(
+	name: string,
+	configFile: string,
+	outputDir: string,
+	target: 'node' | 'web'
+): Promise<TestResult> {
+	console.log(`\n=== ${name} ===`);
+
+	// Build the bundle
+	const buildSuccess = await buildBundle(configFile);
+	if (!buildSuccess) {
+		return { name, success: false, error: 'Build failed' };
+	}
+
+	// For Node.js bundles, try to load them
+	if (target === 'node') {
+		const distDir = join(__dirname, outputDir);
+		try {
+			const files = await readdir(distDir);
+			const jsFile = files.find((f) => f.endsWith('.js'));
+			if (!jsFile) {
+				return {
+					name,
+					success: false,
+					error: 'No JS file found in output',
+				};
+			}
+
+			const bundlePath = join(distDir, jsFile);
+			const loadSuccess = await loadNodeBundle(
+				pathToFileURL(bundlePath).href
+			);
+			if (!loadSuccess) {
+				return { name, success: false, error: 'Failed to load bundle' };
+			}
+		} catch (error) {
+			return {
+				name,
+				success: false,
+				error: `Failed to read output directory: ${error}`,
+			};
+		}
+	}
+
+	// For web bundles, load them in a browser using Playwright
+	if (target === 'web') {
+		const distDir = join(__dirname, outputDir);
+		try {
+			const files = await readdir(distDir);
+			// Look for .js or .mjs files (Vite may use either depending on package type)
+			const jsFile = files.find(
+				(f) => f.endsWith('.js') || f.endsWith('.mjs')
+			);
+			if (!jsFile) {
+				return {
+					name,
+					success: false,
+					error: `No JS file found in output. Files: ${files.join(', ')}`,
+				};
+			}
+
+			const browserResult = await loadWebBundleInBrowser(distDir, jsFile);
+			if (!browserResult.success) {
+				return { name, success: false, error: browserResult.error };
+			}
+		} catch (error) {
+			return {
+				name,
+				success: false,
+				error: `Failed to test web bundle: ${error}`,
+			};
+		}
+	}
+
+	return { name, success: true };
+}
+
+async function main(): Promise<void> {
+	console.log('=== Bundler Tests (ESM) ===');
+	console.log('Testing that @php-wasm/* packages can be bundled with Vite\n');
+
+	await mkdir(join(__dirname, 'dist'), { recursive: true });
+
+	const results: TestResult[] = [];
+
+	// Test 1: Web bundle with static imports
+	results.push(
+		await runTest(
+			'Web Bundle (static imports)',
+			'vite.config.web.ts',
+			'dist/web',
+			'web'
+		)
+	);
+
+	// Test 2: Node bundle with static imports
+	results.push(
+		await runTest(
+			'Node Bundle (static imports)',
+			'vite.config.node-static.ts',
+			'dist/node-static',
+			'node'
+		)
+	);
+
+	// Test 3: Node bundle with dynamic imports
+	results.push(
+		await runTest(
+			'Node Bundle (dynamic imports)',
+			'vite.config.node-dynamic.ts',
+			'dist/node-dynamic',
+			'node'
+		)
+	);
+
+	// Print summary
+	console.log('\n=== Results ===');
+	let allPassed = true;
+	for (const result of results) {
+		if (result.success) {
+			console.log(green(`✓ ${result.name}`));
+		} else {
+			console.log(red(`✗ ${result.name}: ${result.error}`));
+			allPassed = false;
+		}
+	}
+
+	if (allPassed) {
+		console.log(green('\nAll bundler tests passed!'));
+	} else {
+		console.log(red('\nSome bundler tests failed!'));
+		process.exit(1);
+	}
+}
+
+main();

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/vite.config.node-dynamic.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/vite.config.node-dynamic.ts
@@ -24,6 +24,7 @@ export default defineConfig({
 			external: [
 				...builtinModules,
 				...builtinModules.map((m) => `node:${m}`),
+				'fs-ext-extra-prebuilt',
 				/\.wasm$/,
 				/\.so$/,
 				/\.dat$/,

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/vite.config.node-dynamic.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/vite.config.node-dynamic.ts
@@ -1,0 +1,36 @@
+/**
+ * Vite config for bundling node-related packages with dynamic imports.
+ * This config bundles @php-wasm/node and @php-wasm/universal into a Node.js-compatible bundle
+ * using dynamic import() statements.
+ *
+ * Node.js builtins and binary assets are externalized because they're available
+ * at runtime in Node.js environments.
+ */
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+import { builtinModules } from 'module';
+
+export default defineConfig({
+	build: {
+		outDir: 'dist/node-dynamic',
+		lib: {
+			entry: resolve(__dirname, 'entry-node-dynamic-imports.ts'),
+			name: 'PlaygroundNodeDynamic',
+			fileName: 'bundle-node-dynamic-imports',
+			formats: ['es'],
+		},
+		rollupOptions: {
+			// Externalize Node.js builtins and binary assets
+			external: [
+				...builtinModules,
+				...builtinModules.map((m) => `node:${m}`),
+				/\.wasm$/,
+				/\.so$/,
+				/\.dat$/,
+			],
+		},
+		target: 'node18',
+		minify: false,
+		sourcemap: true,
+	},
+});

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/vite.config.node-static.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/vite.config.node-static.ts
@@ -1,0 +1,35 @@
+/**
+ * Vite config for bundling node-related packages with static imports.
+ * This config bundles @php-wasm/node and @php-wasm/universal into a Node.js-compatible bundle.
+ *
+ * Node.js builtins and binary assets are externalized because they're available
+ * at runtime in Node.js environments.
+ */
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+import { builtinModules } from 'module';
+
+export default defineConfig({
+	build: {
+		outDir: 'dist/node-static',
+		lib: {
+			entry: resolve(__dirname, 'entry-node-static-imports.ts'),
+			name: 'PlaygroundNode',
+			fileName: 'bundle-node-static-imports',
+			formats: ['es'],
+		},
+		rollupOptions: {
+			// Externalize Node.js builtins and binary assets
+			external: [
+				...builtinModules,
+				...builtinModules.map((m) => `node:${m}`),
+				/\.wasm$/,
+				/\.so$/,
+				/\.dat$/,
+			],
+		},
+		target: 'node18',
+		minify: false,
+		sourcemap: true,
+	},
+});

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/vite.config.node-static.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/vite.config.node-static.ts
@@ -23,6 +23,7 @@ export default defineConfig({
 			external: [
 				...builtinModules,
 				...builtinModules.map((m) => `node:${m}`),
+				'fs-ext-extra-prebuilt',
 				/\.wasm$/,
 				/\.so$/,
 				/\.dat$/,

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/vite.config.web.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/vite.config.web.ts
@@ -1,0 +1,28 @@
+/**
+ * Vite config for bundling web-related packages for the browser.
+ * This config bundles @php-wasm/web and @php-wasm/universal into a browser-compatible bundle.
+ *
+ * WASM and binary files are externalized because they're loaded dynamically at runtime,
+ * not bundled inline. This matches how real-world applications use these packages.
+ */
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+	build: {
+		outDir: 'dist/web',
+		lib: {
+			entry: resolve(__dirname, 'entry-web-static-imports.ts'),
+			name: 'PlaygroundWeb',
+			fileName: 'bundle-web-static-imports',
+			formats: ['es'],
+		},
+		rollupOptions: {
+			// Externalize binary assets - they're loaded at runtime, not bundled
+			external: [/\.wasm$/, /\.so$/, /\.dat$/],
+		},
+		target: 'esnext',
+		minify: false,
+		sourcemap: true,
+	},
+});

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/package.json
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/package.json
@@ -15,10 +15,16 @@
 	"type": "module",
 	"main": "index.js",
 	"scripts": {
-		"test": "node --experimental-strip-types --experimental-transform-types ./run-tests.ts"
+		"test": "node --experimental-strip-types --experimental-transform-types ./run-tests.ts",
+		"test:bundle": "node --experimental-strip-types --experimental-transform-types ./bundler-tests/run-bundler-tests.ts"
 	},
 	"devDependencies": {
+		"@php-wasm/node": "^1.2.3",
+		"@php-wasm/universal": "^1.2.3",
+		"@php-wasm/web": "^1.2.3",
 		"@types/node": "^22.14.1",
-		"@wp-playground/cli": "^1.2.3"
+		"@wp-playground/cli": "^1.2.3",
+		"playwright": "1.55.1",
+		"vite": "^5.0.0"
 	}
 }

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/run-with-local-packages.sh
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/run-with-local-packages.sh
@@ -24,3 +24,4 @@ npm install
 
 # Run tests
 npm run test
+npm run test:bundle


### PR DESCRIPTION
## Summary
- refreshes upstream WordPress/wordpress-playground#3079 narrowly onto current trunk
- adds Vite bundler smoke tests for the built-package ESM and CommonJS fixtures
- covers browser bundles plus Node static, dynamic import, and require entry points
- wires the new bundle checks into the built-package integration scripts and installs matching Playwright Chromium in CI
- keeps `fs-ext-extra-prebuilt` external in Node bundle smoke tests and in the `@php-wasm/node` ESM package build so native loader assets are resolved from `node_modules`

This intentionally leaves out the stale PHP build-script and Vite extension edits from upstream #3079.

Refs #43.

## Verification
- `bash -n packages/playground/test-built-npm-packages/run-tests.sh packages/playground/test-built-npm-packages/use-local-packages.sh packages/playground/test-built-npm-packages/es-modules-and-vitest/run-with-local-packages.sh packages/playground/test-built-npm-packages/commonjs-and-jest/run-with-local-packages.sh`
- `node --check packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/run-bundler-tests.cjs packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/entry-node-require.cjs packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/entry-node-dynamic-import.cjs packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/entry-web-require.cjs`
- `node --experimental-strip-types --experimental-transform-types --check packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/run-bundler-tests.ts packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/entry-node-static-imports.ts packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/entry-node-dynamic-imports.ts packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/entry-web-static-imports.ts packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/vite.config.web.ts packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/vite.config.node-static.ts packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/vite.config.node-dynamic.ts`
- `npx prettier --check packages/php-wasm/node/build.js packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/vite.config.node-static.ts packages/playground/test-built-npm-packages/es-modules-and-vitest/bundler-tests/vite.config.node-dynamic.ts packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/vite.config.node-require.mjs packages/playground/test-built-npm-packages/commonjs-and-jest/bundler-tests/vite.config.node-dynamic.mjs`
- `npx nx run php-wasm-node:build:bundle --skip-nx-cache`
- `npx nx run php-wasm-node:lint --skip-nx-cache`
- `npx nx run php-wasm-node:typecheck --skip-nx-cache`
- `git diff --check`
- `npm run test:bundle` in both fixtures: Node bundle smoke cases pass; browser smoke cases are left to CI because this local container lacks Playwright system libraries

## CI notes
The previous `test-built-npm-packages` failure was branch-specific and is addressed by commit `e6bd297f6`. The separate `test-e2e-personal-wp` failure matches the shared empty iframe/body timeout seen on several unrelated PRs.
