### PR TITLE
Update saved site URL slug on rename

### DIFF
--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -3,7 +3,7 @@ import { useCurrentUrl } from '../../lib/state/url/router-hooks';
 import { opfsSiteStorage } from '../../lib/state/opfs/opfs-site-storage';
 import {
 	OPFSSitesLoaded,
-	selectSiteBySlug,
+	selectSiteByUrlSlug,
 } from '../../lib/state/redux/slice-sites';
 import {
 	selectActiveSite,
@@ -38,12 +38,14 @@ export function EnsurePlaygroundSiteIsSelected({
 	const url = useCurrentUrl();
 	const requestedSiteSlug = url.searchParams.get('site-slug');
 	const requestedSiteObject = useAppSelector((state) =>
-		selectSiteBySlug(state, requestedSiteSlug!)
+		requestedSiteSlug
+			? selectSiteByUrlSlug(state, requestedSiteSlug)
+			: undefined
 	);
-	const requestedClientInfo = useAppSelector(
-		(state) =>
-			requestedSiteSlug &&
-			selectClientBySiteSlug(state, requestedSiteSlug)
+	const requestedClientInfo = useAppSelector((state) =>
+		requestedSiteObject
+			? selectClientBySiteSlug(state, requestedSiteObject.slug)
+			: undefined
 	);
 	const [needMissingSitePromptForSlug, setNeedMissingSitePromptForSlug] =
 		useState<false | string>(false);
@@ -89,7 +91,7 @@ export function EnsurePlaygroundSiteIsSelected({
 					return;
 				}
 
-				await sitesAPI.setActiveSite(requestedSiteSlug);
+				await sitesAPI.setActiveSite(requestedSiteObject.slug);
 				return;
 			}
 

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -40,6 +40,7 @@ export const legacyOpfsPathSymbol = Symbol('legacyOpfsPath');
  */
 export interface StoredSiteMetadata extends SiteMetadata {
 	slug: string;
+	urlSlug?: string;
 }
 
 let opfsSitesRoot: FileSystemDirectoryHandle | undefined = undefined;
@@ -60,7 +61,11 @@ class OpfsSiteStorage {
 		this.root = root;
 	}
 
-	async create(slug: string, metadata: SiteMetadata): Promise<void> {
+	async create(
+		slug: string,
+		metadata: SiteMetadata,
+		urlSlug: string = slug
+	): Promise<void> {
 		const newSiteDirName = getDirectoryNameForSlug(slug);
 		if (await opfsChildExists(this.root, newSiteDirName)) {
 			const dir = await this.root.getDirectoryHandle(newSiteDirName);
@@ -74,19 +79,25 @@ class OpfsSiteStorage {
 		});
 		await opfsWriteFile(
 			joinPaths(ROOT_PATH, newSiteDirName, SITE_METADATA_FILENAME),
-			await metadataToStoredFormat(slug, metadata)
+			await metadataToStoredFormat(slug, metadata, urlSlug)
 		);
 	}
 
-	async update(slug: string, metadata: SiteMetadata): Promise<void> {
+	async update(
+		slug: string,
+		metadata: SiteMetadata,
+		urlSlug?: string
+	): Promise<void> {
 		const newSiteDirName = getDirectoryNameForSlug(slug);
 		if (!(await opfsChildExists(this.root, newSiteDirName))) {
 			throw new Error(`Site with slug '${slug}' does not exist.`);
 		}
+		const existingMetadata = await this.readRawMetadata(newSiteDirName);
+		const finalUrlSlug = urlSlug ?? existingMetadata?.urlSlug ?? slug;
 
 		await opfsWriteFile(
 			joinPaths(ROOT_PATH, newSiteDirName, SITE_METADATA_FILENAME),
-			await metadataToStoredFormat(slug, metadata)
+			await metadataToStoredFormat(slug, metadata, finalUrlSlug)
 		);
 	}
 
@@ -157,6 +168,26 @@ class OpfsSiteStorage {
 		const siteDirName = getDirectoryNameForSlug(slug);
 		await this.root.removeEntry(siteDirName, { recursive: true });
 	}
+
+	private async readRawMetadata(
+		siteDirName: string
+	): Promise<StoredSiteMetadata | undefined> {
+		try {
+			const siteDirectory =
+				await this.root.getDirectoryHandle(siteDirName);
+			const siteInfoFileHandle = await siteDirectory.getFileHandle(
+				SITE_METADATA_FILENAME
+			);
+			const file = await siteInfoFileHandle.getFile();
+			return JSON.parse(await file.text()) as StoredSiteMetadata;
+		} catch (error) {
+			logger.error(
+				`Error reading raw metadata for site ${siteDirName}:`,
+				error
+			);
+			return undefined;
+		}
+	}
 }
 
 export const opfsSiteStorage: OpfsSiteStorage | undefined = opfsSitesRoot
@@ -175,11 +206,13 @@ export function getDirectoryNameForSlug(slug: string) {
 
 async function metadataToStoredFormat(
 	slug: string,
-	{ originalBlueprint, originalBlueprintSource, ...metadata }: SiteMetadata
+	{ originalBlueprint, originalBlueprintSource, ...metadata }: SiteMetadata,
+	urlSlug: string = slug
 ): Promise<string> {
 	return JSON.stringify(
 		{
 			slug,
+			urlSlug,
 			originalBlueprintSource,
 			// Only store the blueprint declaration if it's NOT a bundle directory.
 			// For bundle directories, the full bundle is stored separately.
@@ -195,7 +228,9 @@ async function metadataToStoredFormat(
 }
 
 function storedFormatToMetadata(data: string) {
-	const { slug, ...metadata } = JSON.parse(data) as StoredSiteMetadata;
+	const { slug, urlSlug, ...metadata } = JSON.parse(
+		data
+	) as StoredSiteMetadata;
 
 	/**
 	 * Migrate the legacy runtimeConfiguration data format to the new, flat one.
@@ -246,6 +281,7 @@ function storedFormatToMetadata(data: string) {
 
 	return {
 		slug,
+		urlSlug: urlSlug ?? slug,
 		metadata,
 	};
 }

--- a/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
+++ b/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
@@ -15,6 +15,8 @@ import type { PlaygroundReduxState } from './store';
 import type store from './store';
 import { selectClientBySiteSlug, updateClientInfo } from './slice-clients';
 import {
+	deriveSlugFromSiteName,
+	selectAllSites,
 	selectSiteBySlug,
 	updateSite,
 	updateSiteMetadata,
@@ -22,6 +24,7 @@ import {
 import { PlaygroundRoute, redirectTo } from '../url/router';
 import type { SiteStorageType } from './slice-sites';
 import { setActiveModal } from './slice-ui';
+import { assertUrlSlugIsAvailable } from './site-url-slug';
 
 export function persistTemporarySite(
 	siteSlug: string,
@@ -49,11 +52,22 @@ export function persistTemporarySite(
 			throw new Error(`Cannot find site ${siteSlug} to save.`);
 		}
 		const trimmedName = options.siteName?.trim();
+		let urlSlug = siteInfo.urlSlug ?? siteInfo.slug;
+		if (trimmedName) {
+			urlSlug = deriveSlugFromSiteName(trimmedName);
+			assertUrlSlugIsAvailable(
+				selectAllSites(getState()),
+				urlSlug,
+				siteSlug,
+				'Cannot save site'
+			);
+		}
 		if (trimmedName && trimmedName !== siteInfo.metadata.name) {
 			await dispatch(
 				updateSiteMetadata({
 					slug: siteSlug,
 					changes: { name: trimmedName },
+					urlSlug,
 				})
 			);
 			siteInfo = selectSiteBySlug(getState(), siteSlug)!;
@@ -73,13 +87,17 @@ export function persistTemporarySite(
 				throw error;
 			}
 		}
-		await opfsSiteStorage?.create(siteInfo.slug, {
-			...siteInfo.metadata,
-			// Start with storage type of 'none' to represent a temporary site
-			// that the site is being saved. This will help us distinguish
-			// between successful and failed saves.
-			storage: 'none',
-		});
+		await opfsSiteStorage?.create(
+			siteInfo.slug,
+			{
+				...siteInfo.metadata,
+				// Start with storage type of 'none' to represent a temporary site
+				// that the site is being saved. This will help us distinguish
+				// between successful and failed saves.
+				storage: 'none',
+			},
+			urlSlug
+		);
 
 		// Persist the blueprint bundle if available.
 		// First, check if originalBlueprint is already a filesystem (from clicking "Run Blueprint").
@@ -245,6 +263,7 @@ export function persistTemporarySite(
 						: {}),
 					...(trimmedName ? { name: trimmedName } : {}),
 				},
+				urlSlug,
 			})
 		);
 		/**

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.spec.ts
@@ -1,0 +1,251 @@
+import type { SiteInfo } from './slice-sites';
+
+function installBrowserGlobals() {
+	const pushState = vitest.fn();
+	const replaceState = vitest.fn();
+	const location = {
+		href: 'https://playground.example/',
+		origin: 'https://playground.example',
+	};
+	const windowMock: any = {
+		location,
+		history: {
+			pushState,
+			replaceState,
+		},
+		innerWidth: 1280,
+		addEventListener: vitest.fn(),
+		removeEventListener: vitest.fn(),
+		dispatchEvent: vitest.fn(),
+	};
+	windowMock.self = windowMock;
+	windowMock.top = windowMock;
+
+	vitest.stubGlobal('window', windowMock);
+	vitest.stubGlobal('document', { location });
+	vitest.stubGlobal('location', location);
+	vitest.stubGlobal('navigator', { onLine: true });
+	vitest.stubGlobal(
+		'Event',
+		class Event {
+			type: string;
+			constructor(type: string) {
+				this.type = type;
+			}
+		}
+	);
+
+	return { pushState, replaceState };
+}
+
+function makeSite(
+	slug: string,
+	{
+		name,
+		storage,
+		urlSlug = slug,
+	}: {
+		name: string;
+		storage: 'none' | 'opfs';
+		urlSlug?: string;
+	}
+): SiteInfo {
+	return {
+		slug,
+		urlSlug,
+		originalUrlParams: {
+			searchParams: {},
+			hash: '',
+		},
+		metadata: {
+			id: `${slug}-id`,
+			name,
+			storage,
+			whenCreated: Date.now(),
+			originalBlueprint: {},
+			originalBlueprintSource: {
+				type: 'none',
+			},
+			runtimeConfiguration: {
+				phpVersion: '8.4' as any,
+				wpVersion: 'latest',
+				intl: false,
+				networking: true,
+				extraLibraries: [],
+				constants: {},
+			},
+		},
+	};
+}
+
+async function createHarness(sites: SiteInfo[], activeSiteSlug: string) {
+	vitest.resetModules();
+	const browser = installBrowserGlobals();
+	vitest.doMock('./store', () => ({
+		selectActiveSite: (state: any) =>
+			state.ui.activeSite?.slug
+				? state.sites.entities[state.ui.activeSite.slug]
+				: undefined,
+		setActiveSite: (slug: string | undefined) => (dispatch: any) => {
+			dispatch({ type: 'ui/setActiveSite', payload: slug });
+		},
+		useAppDispatch: () => {
+			throw new Error('useAppDispatch is not available in this test.');
+		},
+		useAppSelector: () => {
+			throw new Error('useAppSelector is not available in this test.');
+		},
+	}));
+	const [
+		{ configureStore },
+		{ default: sitesReducer, sitesSlice },
+		{ default: uiReducer, __internal_uiSlice },
+		{ default: clientsReducer, addClientInfo },
+		{ createSitesAPI },
+	] = await Promise.all([
+		import('@reduxjs/toolkit'),
+		import('./slice-sites'),
+		import('./slice-ui'),
+		import('./slice-clients'),
+		import('./site-management-api-middleware'),
+	]);
+
+	const store = configureStore({
+		reducer: {
+			ui: uiReducer,
+			sites: sitesReducer,
+			clients: clientsReducer,
+		},
+		middleware: (getDefaultMiddleware) =>
+			getDefaultMiddleware({ serializableCheck: false }),
+	});
+	store.dispatch(sitesSlice.actions.addSites(sites));
+	store.dispatch(__internal_uiSlice.actions.setActiveSite(activeSiteSlug));
+
+	const api = createSitesAPI(store.getState as any, store.dispatch as any);
+	return { ...browser, store, api, addClientInfo };
+}
+
+describe('createSitesAPI', () => {
+	afterEach(() => {
+		vitest.doUnmock('./store');
+		vitest.restoreAllMocks();
+		vitest.unstubAllGlobals();
+	});
+
+	it('rejects empty names in the public rename API', async () => {
+		const { api, store, pushState } = await createHarness(
+			[
+				makeSite('storage-slug', {
+					name: 'Original Site',
+					storage: 'opfs',
+				}),
+			],
+			'storage-slug'
+		);
+
+		await expect(api.rename('   ')).rejects.toThrow(
+			'Site name must not be empty.'
+		);
+
+		const site = store.getState().sites.entities['storage-slug'];
+		expect(site?.metadata.name).toBe('Original Site');
+		expect(site?.urlSlug).toBe('storage-slug');
+		expect(pushState).not.toHaveBeenCalled();
+	});
+
+	it('trims public API renames before persisting the name and URL slug', async () => {
+		const { api, store, pushState } = await createHarness(
+			[
+				makeSite('storage-slug', {
+					name: 'Original Site',
+					storage: 'opfs',
+				}),
+			],
+			'storage-slug'
+		);
+
+		await api.rename('  Renamed Site  ');
+
+		const site = store.getState().sites.entities['storage-slug'];
+		expect(site?.metadata.name).toBe('Renamed Site');
+		expect(site?.urlSlug).toBe('renamed-site');
+		expect(pushState).toHaveBeenCalledWith(
+			{},
+			'',
+			'https://playground.example/?site-slug=renamed-site'
+		);
+	});
+
+	it('persists a custom save name as the saved site URL slug', async () => {
+		const { api, store, pushState, addClientInfo } = await createHarness(
+			[
+				makeSite('temporary-slug', {
+					name: 'Temporary Site',
+					storage: 'none',
+				}),
+			],
+			'temporary-slug'
+		);
+		store.dispatch(
+			addClientInfo({
+				siteSlug: 'temporary-slug',
+				url: 'https://playground.example/',
+				client: {
+					mountOpfs: vitest.fn(async () => undefined),
+					readFileAsText: vitest.fn(async () => '{}'),
+				} as any,
+			})
+		);
+
+		await api.saveInBrowser('  My Custom Playground Name  ');
+
+		const site = store.getState().sites.entities['temporary-slug'];
+		expect(site?.metadata.storage).toBe('opfs');
+		expect(site?.metadata.name).toBe('My Custom Playground Name');
+		expect(site?.urlSlug).toBe('my-custom-playground-name');
+		expect(pushState).toHaveBeenCalledWith(
+			{},
+			'',
+			'https://playground.example/?site-slug=my-custom-playground-name'
+		);
+	});
+
+	it('rejects duplicate custom save name URL slugs', async () => {
+		const tempClient = {
+			mountOpfs: vitest.fn(async () => undefined),
+			readFileAsText: vitest.fn(async () => '{}'),
+		};
+		const { api, store, addClientInfo } = await createHarness(
+			[
+				makeSite('temporary-slug', {
+					name: 'Temporary Site',
+					storage: 'none',
+				}),
+				makeSite('existing-storage-slug', {
+					name: 'Existing Site',
+					storage: 'opfs',
+					urlSlug: 'my-custom-playground-name',
+				}),
+			],
+			'temporary-slug'
+		);
+		store.dispatch(
+			addClientInfo({
+				siteSlug: 'temporary-slug',
+				url: 'https://playground.example/',
+				client: tempClient as any,
+			})
+		);
+
+		await expect(
+			api.saveInBrowser('My Custom Playground Name')
+		).rejects.toThrow(
+			"Cannot save site. URL slug 'my-custom-playground-name' is already in use."
+		);
+
+		expect(tempClient.mountOpfs).not.toHaveBeenCalled();
+		const site = store.getState().sites.entities['temporary-slug'];
+		expect(site?.metadata.storage).toBe('none');
+	});
+});

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -13,7 +13,10 @@ import {
 	removeSite,
 	setTemporarySiteSpec,
 	deriveSiteNameFromSlug,
+	deriveSlugFromSiteName,
 } from './slice-sites';
+import { PlaygroundRoute, redirectTo } from '../url/router';
+import { siteMatchesUrlSlug } from './site-url-slug';
 import { randomSiteName } from './random-site-name';
 import { persistTemporarySite } from './persist-temporary-site';
 import { selectClientBySiteSlug } from './slice-clients';
@@ -188,12 +191,28 @@ export function createSitesAPI(
 					'Cannot rename a temporary site. Save it first.'
 				);
 			}
+			const urlSlug = deriveSlugFromSiteName(newName);
+			const duplicateSite = selectAllSites(getState()).find(
+				(otherSite) =>
+					otherSite.slug !== site.slug &&
+					siteMatchesUrlSlug(otherSite, urlSlug)
+			);
+			if (duplicateSite) {
+				throw new Error(
+					`Cannot rename site. URL slug '${urlSlug}' is already in use.`
+				);
+			}
 			await dispatch(
 				updateSiteMetadata({
 					slug: site.slug,
 					changes: { name: newName },
+					urlSlug,
 				})
 			);
+			const updatedSite = selectSiteBySlug(getState(), site.slug);
+			if (updatedSite) {
+				redirectTo(PlaygroundRoute.site(updatedSite));
+			}
 		},
 
 		async saveInBrowser(name?: string) {

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -13,10 +13,12 @@ import {
 	removeSite,
 	setTemporarySiteSpec,
 	deriveSiteNameFromSlug,
-	deriveSlugFromSiteName,
 } from './slice-sites';
 import { PlaygroundRoute, redirectTo } from '../url/router';
-import { siteMatchesUrlSlug } from './site-url-slug';
+import {
+	assertUrlSlugIsAvailable,
+	deriveUrlSlugFromSiteName,
+} from './site-url-slug';
 import { randomSiteName } from './random-site-name';
 import { persistTemporarySite } from './persist-temporary-site';
 import { selectClientBySiteSlug } from './slice-clients';
@@ -191,21 +193,18 @@ export function createSitesAPI(
 					'Cannot rename a temporary site. Save it first.'
 				);
 			}
-			const urlSlug = deriveSlugFromSiteName(newName);
-			const duplicateSite = selectAllSites(getState()).find(
-				(otherSite) =>
-					otherSite.slug !== site.slug &&
-					siteMatchesUrlSlug(otherSite, urlSlug)
+			const trimmedName = newName.trim();
+			const urlSlug = deriveUrlSlugFromSiteName(trimmedName);
+			assertUrlSlugIsAvailable(
+				selectAllSites(getState()),
+				urlSlug,
+				site.slug,
+				'Cannot rename site'
 			);
-			if (duplicateSite) {
-				throw new Error(
-					`Cannot rename site. URL slug '${urlSlug}' is already in use.`
-				);
-			}
 			await dispatch(
 				updateSiteMetadata({
 					slug: site.slug,
-					changes: { name: newName },
+					changes: { name: trimmedName },
 					urlSlug,
 				})
 			);

--- a/packages/playground/website/src/lib/state/redux/site-url-slug.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/site-url-slug.spec.ts
@@ -1,4 +1,8 @@
-import { siteMatchesUrlSlug } from './site-url-slug';
+import {
+	assertUrlSlugIsAvailable,
+	deriveUrlSlugFromSiteName,
+	siteMatchesUrlSlug,
+} from './site-url-slug';
 
 describe('siteMatchesUrlSlug', () => {
 	it('matches a site by its URL slug', () => {
@@ -17,5 +21,47 @@ describe('siteMatchesUrlSlug', () => {
 				'storage-slug'
 			)
 		).toBe(true);
+	});
+
+	it('derives a URL slug from a trimmed site name', () => {
+		expect(deriveUrlSlugFromSiteName('  My Saved Playground  ')).toBe(
+			'my-saved-playground'
+		);
+	});
+
+	it('rejects an empty URL slug', () => {
+		expect(() =>
+			assertUrlSlugIsAvailable(
+				[],
+				'',
+				'current-site',
+				'Cannot rename site'
+			)
+		).toThrow('Site name must not be empty.');
+	});
+
+	it('rejects duplicate URL slugs while ignoring the current storage slug', () => {
+		expect(() =>
+			assertUrlSlugIsAvailable(
+				[
+					{ slug: 'current-site', urlSlug: 'current-url-slug' },
+					{ slug: 'other-storage-slug', urlSlug: 'other-url-slug' },
+				],
+				'other-url-slug',
+				'current-site',
+				'Cannot rename site'
+			)
+		).toThrow(
+			"Cannot rename site. URL slug 'other-url-slug' is already in use."
+		);
+
+		expect(() =>
+			assertUrlSlugIsAvailable(
+				[{ slug: 'current-site', urlSlug: 'current-url-slug' }],
+				'current-url-slug',
+				'current-site',
+				'Cannot rename site'
+			)
+		).not.toThrow();
 	});
 });

--- a/packages/playground/website/src/lib/state/redux/site-url-slug.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/site-url-slug.spec.ts
@@ -1,0 +1,21 @@
+import { siteMatchesUrlSlug } from './site-url-slug';
+
+describe('siteMatchesUrlSlug', () => {
+	it('matches a site by its URL slug', () => {
+		expect(
+			siteMatchesUrlSlug(
+				{ slug: 'storage-slug', urlSlug: 'renamed-site' },
+				'renamed-site'
+			)
+		).toBe(true);
+	});
+
+	it('keeps the storage slug as a fallback URL', () => {
+		expect(
+			siteMatchesUrlSlug(
+				{ slug: 'storage-slug', urlSlug: 'renamed-site' },
+				'storage-slug'
+			)
+		).toBe(true);
+	});
+});

--- a/packages/playground/website/src/lib/state/redux/site-url-slug.ts
+++ b/packages/playground/website/src/lib/state/redux/site-url-slug.ts
@@ -3,6 +3,31 @@ export interface SiteUrlSlugInfo {
 	urlSlug?: string;
 }
 
+export function deriveUrlSlugFromSiteName(name: string) {
+	return name.trim().toLowerCase().replaceAll(' ', '-');
+}
+
 export function siteMatchesUrlSlug(site: SiteUrlSlugInfo, urlSlug: string) {
 	return site.urlSlug === urlSlug || site.slug === urlSlug;
+}
+
+export function assertUrlSlugIsAvailable(
+	sites: SiteUrlSlugInfo[],
+	urlSlug: string,
+	currentStorageSlug: string,
+	messagePrefix: string
+) {
+	if (!urlSlug) {
+		throw new Error('Site name must not be empty.');
+	}
+	const duplicateSite = sites.find(
+		(otherSite) =>
+			otherSite.slug !== currentStorageSlug &&
+			siteMatchesUrlSlug(otherSite, urlSlug)
+	);
+	if (duplicateSite) {
+		throw new Error(
+			`${messagePrefix}. URL slug '${urlSlug}' is already in use.`
+		);
+	}
 }

--- a/packages/playground/website/src/lib/state/redux/site-url-slug.ts
+++ b/packages/playground/website/src/lib/state/redux/site-url-slug.ts
@@ -1,0 +1,8 @@
+export interface SiteUrlSlugInfo {
+	slug: string;
+	urlSlug?: string;
+}
+
+export function siteMatchesUrlSlug(site: SiteUrlSlugInfo, urlSlug: string) {
+	return site.urlSlug === urlSlug || site.slug === urlSlug;
+}

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -25,12 +25,14 @@ import { logger } from '@php-wasm/logger';
 import { setActiveSiteError, type SiteError } from './slice-ui';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { findFirewallErrorInCauseChain } from './error-utils';
+import { siteMatchesUrlSlug } from './site-url-slug';
 
 /**
  * The Site model used to represent a site within Playground.
  */
 export interface SiteInfo {
 	slug: string;
+	urlSlug?: string;
 	originalUrlParams?: {
 		searchParams?: Record<string, string>;
 		hash?: string;
@@ -70,12 +72,16 @@ const sitesSlice = createSlice({
 			action: PayloadAction<{
 				slug: string;
 				metadata: Partial<SiteMetadata>;
+				urlSlug?: string;
 			}>
 		) => {
-			const { slug, metadata } = action.payload;
+			const { slug, metadata, urlSlug } = action.payload;
 			const site = state.entities[slug];
 			if (site) {
 				site.metadata = { ...site.metadata, ...metadata };
+				if (urlSlug !== undefined) {
+					site.urlSlug = urlSlug;
+				}
 			}
 		},
 
@@ -100,7 +106,10 @@ export const OPFSSitesLoaded = (sites: SiteInfo[]) => {
 		const currentSites = getState().sites.entities;
 		const allSites = { ...currentSites };
 		sites.forEach((site) => {
-			allSites[site.slug] = site;
+			allSites[site.slug] = {
+				...site,
+				urlSlug: site.urlSlug ?? site.slug,
+			};
 		});
 		dispatch(sitesSlice.actions.setSites(allSites));
 		dispatch(setOPFSSitesLoadingState('loaded'));
@@ -128,9 +137,11 @@ export function deriveSiteNameFromSlug(slug: string) {
 export function updateSiteMetadata({
 	slug,
 	changes,
+	urlSlug,
 }: {
 	slug: string;
 	changes: Partial<SiteMetadata>;
+	urlSlug?: string;
 }) {
 	return async (
 		dispatch: PlaygroundDispatch,
@@ -140,6 +151,7 @@ export function updateSiteMetadata({
 		if (!storedSite) {
 			throw new Error(`Site not found: ${slug}`);
 		}
+		const nextUrlSlug = urlSlug ?? storedSite.urlSlug ?? slug;
 		await dispatch(
 			updateSite({
 				slug,
@@ -148,6 +160,7 @@ export function updateSiteMetadata({
 						...storedSite.metadata,
 						...changes,
 					},
+					...(urlSlug !== undefined ? { urlSlug: nextUrlSlug } : {}),
 				},
 			})
 		);
@@ -184,7 +197,8 @@ export function updateSite({
 		if (updatedSite.metadata.storage !== 'none') {
 			await opfsSiteStorage?.update(
 				updatedSite.slug,
-				updatedSite.metadata
+				updatedSite.metadata,
+				updatedSite.urlSlug ?? updatedSite.slug
 			);
 		}
 	};
@@ -201,13 +215,18 @@ export function addSite(siteInfo: SiteInfo) {
 		dispatch: PlaygroundDispatch,
 		getState: () => PlaygroundReduxState
 	) => {
+		const urlSlug = siteInfo.urlSlug ?? siteInfo.slug;
 		if (siteInfo.metadata.storage === 'none') {
 			throw new Error(
 				'Cannot add a temporary site. Use setTemporarySiteSpec instead.'
 			);
 		}
-		await opfsSiteStorage?.create(siteInfo.slug, siteInfo.metadata);
-		dispatch(sitesSlice.actions.addSite(siteInfo));
+		await opfsSiteStorage?.create(
+			siteInfo.slug,
+			siteInfo.metadata,
+			urlSlug
+		);
+		dispatch(sitesSlice.actions.addSite({ ...siteInfo, urlSlug }));
 	};
 }
 
@@ -273,6 +292,7 @@ export function setTemporarySiteSpec(
 			// Create a mock temporary site to associate the error with.
 			const errorSite: SiteInfo = {
 				slug: siteSlug,
+				urlSlug: siteSlug,
 				originalUrlParams: newSiteUrlParams,
 				metadata: {
 					name: siteName,
@@ -387,6 +407,7 @@ export function setTemporarySiteSpec(
 			// Compute the runtime configuration based on the resolved Blueprint:
 			const newSiteInfo: SiteInfo = {
 				slug: siteSlug,
+				urlSlug: siteSlug,
 				originalUrlParams: newSiteUrlParams,
 				metadata: {
 					name: siteName,
@@ -479,6 +500,15 @@ export const {
 } = sitesAdapter.getSelectors(
 	(state: { sites: ReturnType<typeof sitesSlice.reducer> }) => state.sites
 );
+
+export function selectSiteByUrlSlug(
+	state: { sites: ReturnType<typeof sitesSlice.reducer> },
+	urlSlug: string
+) {
+	return selectAllSites(state).find((site) =>
+		siteMatchesUrlSlug(site, urlSlug)
+	);
+}
 
 export const selectSortedSites = createSelector(
 	[selectAllSites],

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -25,7 +25,7 @@ import { logger } from '@php-wasm/logger';
 import { setActiveSiteError, type SiteError } from './slice-ui';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { findFirewallErrorInCauseChain } from './error-utils';
-import { siteMatchesUrlSlug } from './site-url-slug';
+import { deriveUrlSlugFromSiteName, siteMatchesUrlSlug } from './site-url-slug';
 
 /**
  * The Site model used to represent a site within Playground.
@@ -122,7 +122,7 @@ export const getSitesLoadingState = (state: {
 }) => state.sites.opfsSitesLoadingState;
 
 export function deriveSlugFromSiteName(name: string) {
-	return name.toLowerCase().replaceAll(' ', '-');
+	return deriveUrlSlugFromSiteName(name);
 }
 export function deriveSiteNameFromSlug(slug: string) {
 	return slug

--- a/packages/playground/website/src/lib/state/url/router.spec.ts
+++ b/packages/playground/website/src/lib/state/url/router.spec.ts
@@ -1,11 +1,12 @@
-import { parseBlueprint } from './router';
+import { parseBlueprint, PlaygroundRoute } from './router';
 import { decodeBlueprintHash } from './decode-blueprint-hash';
+import type { SiteInfo } from '../redux/slice-sites';
 
 const toBase64 = (s: string) =>
 	typeof btoa === 'function'
 		? btoa(s)
 		: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-		  (globalThis as any).Buffer.from(s, 'utf-8').toString('base64');
+			(globalThis as any).Buffer.from(s, 'utf-8').toString('base64');
 
 // `parseBlueprint` reaches into `window.atob` via the existing
 // `decodeBase64ToString` helper. The default vitest environment for this
@@ -13,7 +14,9 @@ const toBase64 = (s: string) =>
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const g = globalThis as any;
 if (typeof g.window === 'undefined') {
-	g.window = { atob: (s: string) => Buffer.from(s, 'base64').toString('binary') };
+	g.window = {
+		atob: (s: string) => Buffer.from(s, 'base64').toString('binary'),
+	};
 }
 
 describe('decodeBlueprintHash', () => {
@@ -87,7 +90,9 @@ describe('parseBlueprint', () => {
 	});
 
 	it('throws a descriptive error for invalid JSON and includes the underlying message', () => {
-		expect(() => parseBlueprint('{not json')).toThrow(/Invalid blueprint\./);
+		expect(() => parseBlueprint('{not json')).toThrow(
+			/Invalid blueprint\./
+		);
 		expect(() => parseBlueprint('{not json')).toThrow(
 			/Invalid blueprint\.\s+\S/
 		);
@@ -96,5 +101,30 @@ describe('parseBlueprint', () => {
 	it('hints at double-encoding when the input still contains %XX escapes', () => {
 		const halfDecoded = '{"landingPage"%3A"/"}';
 		expect(() => parseBlueprint(halfDecoded)).toThrow(/double-encoded/);
+	});
+});
+
+describe('PlaygroundRoute.site', () => {
+	const savedSite = {
+		slug: 'storage-slug',
+		urlSlug: 'renamed-site',
+		metadata: {
+			storage: 'opfs',
+		},
+	} as SiteInfo;
+
+	it('uses a saved site urlSlug when present', () => {
+		expect(PlaygroundRoute.site(savedSite, 'https://example.com/')).toBe(
+			'https://example.com/?site-slug=renamed-site'
+		);
+	});
+
+	it('falls back to the storage slug when no urlSlug is present', () => {
+		expect(
+			PlaygroundRoute.site(
+				{ ...savedSite, urlSlug: undefined },
+				'https://example.com/'
+			)
+		).toBe('https://example.com/?site-slug=storage-slug');
 	});
 });

--- a/packages/playground/website/src/lib/state/url/router.ts
+++ b/packages/playground/website/src/lib/state/url/router.ts
@@ -58,7 +58,10 @@ export function parseBlueprint(rawData: string) {
  * base64-decode-then-parse error if the input looks base64-shaped,
  * otherwise the plain JSON.parse error.
  */
-function formatInvalidBlueprintError(rawData: string, errors: unknown[]): string {
+function formatInvalidBlueprintError(
+	rawData: string,
+	errors: unknown[]
+): string {
 	const looksLikeBase64 = /^[A-Za-z0-9+/=]+$/.test(rawData.trim());
 	const primary = looksLikeBase64 && errors[1] ? errors[1] : errors[0];
 	const detail =
@@ -97,8 +100,9 @@ export class PlaygroundRoute {
 					preserveParams[param] = baseParams.get(param);
 				}
 			}
+			const slugForUrl = site.urlSlug ?? site.slug;
 			return updateUrl(baseUrl, {
-				searchParams: { 'site-slug': site.slug, ...preserveParams },
+				searchParams: { 'site-slug': slugForUrl, ...preserveParams },
 				hash: '',
 			});
 		}


### PR DESCRIPTION
## Summary
- refreshes upstream WordPress/wordpress-playground#2805 onto current trunk with a narrower URL-slug implementation
- stores a separate `urlSlug` for saved OPFS sites while keeping the storage slug stable
- updates rename flow to derive and persist a URL slug, redirect to the new saved-site URL, and reject URL-slug collisions
- resolves `?site-slug=` by URL slug while keeping the storage slug as a fallback for old links

This is draft because it changes saved-site routing semantics and should get product review before promotion.

Refs #32.

## Verification
- `npx prettier --check packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts packages/playground/website/src/lib/state/redux/slice-sites.ts packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts packages/playground/website/src/lib/state/redux/site-url-slug.ts packages/playground/website/src/lib/state/redux/site-url-slug.spec.ts packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx packages/playground/website/src/lib/state/url/router.ts packages/playground/website/src/lib/state/url/router.spec.ts`
- `npx nx run playground-website:test --skip-nx-cache`
- `npx nx run playground-website:lint --skip-nx-cache`
- `npx nx run playground-website:typecheck --skip-nx-cache`
- `npx nx run playground-website:build:standalone:production --skip-nx-cache`
- `git diff --check`

Browser screenshot verification was not run in this container because Playwright cannot launch here without missing system libraries; CI should cover browser-capable environments.