### PR TITLE
Support caller-provided socket timeouts

### DIFF
--- a/packages/php-wasm/compile/php/phpwasm-emscripten-library.js
+++ b/packages/php-wasm/compile/php/phpwasm-emscripten-library.js
@@ -24,6 +24,7 @@ const LibraryExample = {
 		POLLHUP: Number('{{{cDefs.POLLHUP}}}'),
 		SETFL_MASK:
 			Number('{{{cDefs.O_APPEND}}}') | Number('{{{cDefs.O_NONBLOCK}}}'),
+		socketTimeouts: new Map(),
 		// These macros are not defined in Emscripten at the time of writing:
 		// emscripten_O_NDELAY |
 		// emscripten_O_DIRECT |
@@ -467,6 +468,33 @@ const LibraryExample = {
 		},
 		noop: function () {},
 
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+
+			return seconds * 1000 + Math.ceil(microseconds / 1000);
+		},
+
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](
@@ -529,6 +557,8 @@ const LibraryExample = {
 		 * @returns 0 on success, -1 on failure
 		 */
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
+
 			// This implementation only supports websockets at the moment
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
@@ -1011,10 +1041,14 @@ const LibraryExample = {
 	/**
 	 * Shims setsockopt(2) functionality for asynchronous websockets:
 	 * https://man7.org/linux/man-pages/man2/setsockopt.2.html
-	 * The only supported options are SO_KEEPALIVE and TCP_NODELAY.
+	 * The supported options are SO_KEEPALIVE, TCP_NODELAY, SO_RCVTIMEO,
+	 * and SO_SNDTIMEO.
 	 *
-	 * Technically these options are propagated to the WebSockets proxy
-	 * server which then sets them on the underlying TCP connection.
+	 * SO_KEEPALIVE and TCP_NODELAY are propagated to the WebSockets proxy
+	 * server, which then sets them on the underlying TCP connection.
+	 *
+	 * SO_RCVTIMEO and SO_SNDTIMEO are stored per socket. wasm_connect()
+	 * uses SO_SNDTIMEO for connection establishment timeouts.
 	 *
 	 * @param {int} socketd Socket descriptor
 	 * @param {int} level  Level at which the option is defined
@@ -1038,27 +1072,38 @@ const LibraryExample = {
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
 
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
+
 		// Options that we can forward to the WebSocket proxy
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
 
-		// Options that we acknowledge but don't actually implement
-		// (WebSocket connections handle timeouts differently)
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-
-		// For ignorable options, just return success
-		if (isIgnorable) {
-			return 0;
 		}
 
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
@@ -1158,8 +1203,8 @@ const LibraryExample = {
 				return;
 			}
 
-			// Wait for the connection to be established
-			const timeout = 30000; // 30 second timeout
+			// Wait for the connection to be established.
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 30000;
 			let resolved = false;
 
 			const timeoutId = setTimeout(() => {

--- a/packages/php-wasm/compile/php/phpwasm-emscripten-library.js
+++ b/packages/php-wasm/compile/php/phpwasm-emscripten-library.js
@@ -1017,7 +1017,15 @@ const LibraryExample = {
 	 */
 	wasm_recv: function (sockfd, buffer, size, flags) {
 		return Asyncify.handleSleep((wakeUp) => {
+			const receiveTimeout =
+				PHPWASM.socketTimeouts.get(sockfd)?.receive;
+			const startedAt = Date.now();
+			let resolved = false;
+
 			const poll = function () {
+				if (resolved) {
+					return;
+				}
 				let newl = ___syscall_recvfrom(
 					sockfd,
 					buffer,
@@ -1027,10 +1035,20 @@ const LibraryExample = {
 					null
 				);
 				if (newl > 0) {
+					resolved = true;
 					wakeUp(newl);
-				} else if (newl === -6) {
+				} else if (newl === -ERRNO_CODES.EAGAIN) {
+					if (
+						receiveTimeout > 0 &&
+						Date.now() - startedAt >= receiveTimeout
+					) {
+						resolved = true;
+						wakeUp(-ERRNO_CODES.EAGAIN);
+						return;
+					}
 					setTimeout(poll, 20);
 				} else {
+					resolved = true;
 					wakeUp(0);
 				}
 			};
@@ -1047,8 +1065,8 @@ const LibraryExample = {
 	 * SO_KEEPALIVE and TCP_NODELAY are propagated to the WebSockets proxy
 	 * server, which then sets them on the underlying TCP connection.
 	 *
-	 * SO_RCVTIMEO and SO_SNDTIMEO are stored per socket. wasm_connect()
-	 * uses SO_SNDTIMEO for connection establishment timeouts.
+		 * SO_RCVTIMEO and SO_SNDTIMEO are stored per socket. wasm_recv()
+		 * uses SO_RCVTIMEO and wasm_connect() uses SO_SNDTIMEO.
 	 *
 	 * @param {int} socketd Socket descriptor
 	 * @param {int} level  Level at which the option is defined
@@ -1203,45 +1221,73 @@ const LibraryExample = {
 				return;
 			}
 
-			// Wait for the connection to be established.
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 30000;
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 30000;
 			let resolved = false;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
 
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
 
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
 
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 
 			ws.addEventListener('open', handleOpen);

--- a/packages/php-wasm/node-builds/5-2/asyncify/php_5_2.js
+++ b/packages/php-wasm/node-builds/5-2/asyncify/php_5_2.js
@@ -6145,6 +6145,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			// TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
 			if (PHPLoader.bindUserSpace) {
@@ -6622,6 +6623,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			// This implementation only supports websockets at the moment
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
@@ -6707,7 +6709,7 @@ export function init(RuntimeName, PHPLoader) {
 				return;
 			}
 			// Wait for the connection to be established
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			// 30 second timeout
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
@@ -9515,24 +9517,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
-		// Options that we can forward to the WebSocket proxy
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		// Options that we acknowledge but don't actually implement
-		// (WebSocket connections handle timeouts differently)
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		// For ignorable options, just return success
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/node-builds/5-2/asyncify/php_5_2.js
+++ b/packages/php-wasm/node-builds/5-2/asyncify/php_5_2.js
@@ -6575,6 +6575,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](
@@ -6708,42 +6731,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			// Wait for the connection to be established
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
-			// 30 second timeout
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);

--- a/packages/php-wasm/node-builds/5-2/jspi/php_5_2.js
+++ b/packages/php-wasm/node-builds/5-2/jspi/php_5_2.js
@@ -6086,6 +6086,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			// TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
 			if (PHPLoader.bindUserSpace) {
@@ -6563,6 +6564,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			// This implementation only supports websockets at the moment
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
@@ -6648,7 +6650,7 @@ export function init(RuntimeName, PHPLoader) {
 				return;
 			}
 			// Wait for the connection to be established
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			// 30 second timeout
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
@@ -9450,24 +9452,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
-		// Options that we can forward to the WebSocket proxy
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		// Options that we acknowledge but don't actually implement
-		// (WebSocket connections handle timeouts differently)
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		// For ignorable options, just return success
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/node-builds/5-2/jspi/php_5_2.js
+++ b/packages/php-wasm/node-builds/5-2/jspi/php_5_2.js
@@ -6516,6 +6516,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](
@@ -6649,42 +6672,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			// Wait for the connection to be established
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
-			// 30 second timeout
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);

--- a/packages/php-wasm/node-builds/7-4/asyncify/php_7_4.js
+++ b/packages/php-wasm/node-builds/7-4/asyncify/php_7_4.js
@@ -6673,6 +6673,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](
@@ -6806,42 +6829,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			// Wait for the connection to be established
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
-			// 30 second timeout
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);
@@ -10193,7 +10247,15 @@ export function init(RuntimeName, PHPLoader) {
 
 	var _wasm_recv = function (sockfd, buffer, size, flags) {
 		return Asyncify.handleSleep((wakeUp) => {
+			const receiveTimeout =
+				PHPWASM.socketTimeouts.get(sockfd)?.receive;
+			const startedAt = Date.now();
+			let resolved = false;
+
 			const poll = function () {
+				if (resolved) {
+					return;
+				}
 				let newl = ___syscall_recvfrom(
 					sockfd,
 					buffer,
@@ -10203,10 +10265,20 @@ export function init(RuntimeName, PHPLoader) {
 					null
 				);
 				if (newl > 0) {
+					resolved = true;
 					wakeUp(newl);
-				} else if (newl === -6) {
+				} else if (newl === -ERRNO_CODES.EAGAIN) {
+					if (
+						receiveTimeout > 0 &&
+						Date.now() - startedAt >= receiveTimeout
+					) {
+						resolved = true;
+						wakeUp(-ERRNO_CODES.EAGAIN);
+						return;
+					}
 					setTimeout(poll, 20);
 				} else {
+					resolved = true;
 					wakeUp(0);
 				}
 			};

--- a/packages/php-wasm/node-builds/7-4/asyncify/php_7_4.js
+++ b/packages/php-wasm/node-builds/7-4/asyncify/php_7_4.js
@@ -6243,6 +6243,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			// TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
 			if (PHPLoader.bindUserSpace) {
@@ -6720,6 +6721,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			// This implementation only supports websockets at the moment
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
@@ -6805,7 +6807,7 @@ export function init(RuntimeName, PHPLoader) {
 				return;
 			}
 			// Wait for the connection to be established
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			// 30 second timeout
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
@@ -9800,24 +9802,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
-		// Options that we can forward to the WebSocket proxy
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		// Options that we acknowledge but don't actually implement
-		// (WebSocket connections handle timeouts differently)
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		// For ignorable options, just return success
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/node-builds/7-4/jspi/php_7_4.js
+++ b/packages/php-wasm/node-builds/7-4/jspi/php_7_4.js
@@ -5949,42 +5949,73 @@ function _wasm_connect(sockfd, addr, addrlen) {
       wakeUp(-ERRNO_CODES.ECONNREFUSED);
       return;
     }
-    // Wait for the connection to be established
-    const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
-    // 30 second timeout
+    // Wait for the connection to be established. A zero timeval
+    // disables the timeout, matching SO_SNDTIMEO semantics.
+    const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+    const timeout = sendTimeout ?? 3e4;
     let resolved = false;
-    const timeoutId = setTimeout(() => {
-      if (!resolved) {
-        resolved = true;
-        wakeUp(-ERRNO_CODES.ETIMEDOUT);
-      }
-    }, timeout);
-    const handleOpen = () => {
-      if (!resolved) {
-        resolved = true;
+    let timeoutId;
+    let handleOpen;
+    let handleError;
+    let handleClose;
+    const peer = PHPWASM.getAllPeers(sock).find(
+      (candidate) => candidate.socket === ws
+    );
+
+    const cleanupConnectListeners = () => {
+      if (typeof timeoutId !== "undefined") {
         clearTimeout(timeoutId);
-        ws.removeEventListener("error", handleError);
-        ws.removeEventListener("close", handleClose);
-        wakeUp(0);
+      }
+      ws.removeEventListener("open", handleOpen);
+      ws.removeEventListener("error", handleError);
+      ws.removeEventListener("close", handleClose);
+    };
+
+    const cleanupFailedConnect = (errno) => {
+      try {
+        if (
+          ws.readyState !== ws.CLOSING &&
+          ws.readyState !== ws.CLOSED
+        ) {
+          ws.close();
+        }
+      } catch (e) {
+        // Ignore close errors on an already-failed connect.
+      }
+      if (peer) {
+        SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+      }
+      sock.connecting = false;
+      sock.error = errno;
+    };
+
+    const finishConnect = (result) => {
+      if (!resolved) {
+        resolved = true;
+        cleanupConnectListeners();
+        if (result < 0) {
+          cleanupFailedConnect(-result);
+        }
+        wakeUp(result);
       }
     };
-    const handleError = () => {
-      if (!resolved) {
-        resolved = true;
-        clearTimeout(timeoutId);
-        ws.removeEventListener("open", handleOpen);
-        ws.removeEventListener("close", handleClose);
-        wakeUp(-ERRNO_CODES.ECONNREFUSED);
-      }
+
+    if (timeout > 0) {
+      timeoutId = setTimeout(() => {
+        finishConnect(-ERRNO_CODES.ETIMEDOUT);
+      }, timeout);
+    }
+
+    handleOpen = () => {
+      finishConnect(0);
     };
-    const handleClose = () => {
-      if (!resolved) {
-        resolved = true;
-        clearTimeout(timeoutId);
-        ws.removeEventListener("open", handleOpen);
-        ws.removeEventListener("error", handleError);
-        wakeUp(-ERRNO_CODES.ECONNREFUSED);
-      }
+
+    handleError = () => {
+      finishConnect(-ERRNO_CODES.ECONNREFUSED);
+    };
+
+    handleClose = () => {
+      finishConnect(-ERRNO_CODES.ECONNREFUSED);
     };
     ws.addEventListener("open", handleOpen);
     ws.addEventListener("error", handleError);
@@ -8884,13 +8915,26 @@ var FS_createDevice = (...args) => FS.createDevice(...args);
 
 var _wasm_recv = function(sockfd, buffer, size, flags) {
   return Asyncify.handleSleep(wakeUp => {
+    const receiveTimeout = PHPWASM.socketTimeouts.get(sockfd)?.receive;
+    const startedAt = Date.now();
+    let resolved = false;
     const poll = function() {
+      if (resolved) {
+        return;
+      }
       let newl = ___syscall_recvfrom(sockfd, buffer, size, flags, null, null);
       if (newl > 0) {
+        resolved = true;
         wakeUp(newl);
-      } else if (newl === -6) {
+      } else if (newl === -ERRNO_CODES.EAGAIN) {
+        if (receiveTimeout > 0 && Date.now() - startedAt >= receiveTimeout) {
+          resolved = true;
+          wakeUp(-ERRNO_CODES.EAGAIN);
+          return;
+        }
         setTimeout(poll, 20);
       } else {
+        resolved = true;
         wakeUp(0);
       }
     };

--- a/packages/php-wasm/node-builds/7-4/jspi/php_7_4.js
+++ b/packages/php-wasm/node-builds/7-4/jspi/php_7_4.js
@@ -5411,6 +5411,7 @@ var PHPWASM = {
   O_NONBLOCK: 2048,
   POLLHUP: 16,
   SETFL_MASK: 3072,
+  socketTimeouts: new Map,
   init: function() {
     // TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
     if (PHPLoader.bindUserSpace) {
@@ -5807,6 +5808,24 @@ var PHPWASM = {
     return [ promise, cancel ];
   },
   noop: function() {},
+  parseSocketTimeout: function(optionValuePtr, optionLen) {
+    if (!optionValuePtr || optionLen < 8) {
+      return null;
+    }
+    let seconds;
+    let microseconds;
+    if (optionLen >= 16) {
+      seconds = Number(HEAP64[optionValuePtr >> 3]);
+      microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+    } else {
+      seconds = HEAP32[optionValuePtr >> 2];
+      microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+    }
+    if (!Number.isFinite(seconds) || !Number.isFinite(microseconds) || seconds < 0 || microseconds < 0) {
+      return null;
+    }
+    return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+  },
   spawnProcess: function(command, args, options) {
     if (Module["spawnProcess"]) {
       const spawned = Module["spawnProcess"](command, args, /**
@@ -5845,6 +5864,7 @@ var PHPWASM = {
     throw e;
   },
   shutdownSocket: function(socketd, how) {
+    PHPWASM.socketTimeouts.delete(socketd);
     // This implementation only supports websockets at the moment
     const sock = getSocketFromFD(socketd);
     const peer = Object.values(sock.peers)[0];
@@ -5930,7 +5950,7 @@ function _wasm_connect(sockfd, addr, addrlen) {
       return;
     }
     // Wait for the connection to be established
-    const timeout = 3e4;
+    const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
     // 30 second timeout
     let resolved = false;
     const timeoutId = setTimeout(() => {
@@ -8702,18 +8722,25 @@ function _wasm_setsockopt(socketd, level, optionName, optionValuePtr, optionLen)
   const SO_SNDTIMEO = 67;
   const IPPROTO_TCP = 6;
   const TCP_NODELAY = 1;
+  if (level === SOL_SOCKET && (optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)) {
+    const timeoutMs = PHPWASM.parseSocketTimeout(optionValuePtr, optionLen);
+    if (timeoutMs === null) {
+      return -1;
+    }
+    const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+    if (optionName === SO_RCVTIMEO) {
+      timeouts.receive = timeoutMs;
+    } else {
+      timeouts.send = timeoutMs;
+    }
+    PHPWASM.socketTimeouts.set(socketd, timeouts);
+    return 0;
+  }
   // Options that we can forward to the WebSocket proxy
   const isForwardable = (level === SOL_SOCKET && optionName === SO_KEEPALIVE) || (level === IPPROTO_TCP && optionName === TCP_NODELAY);
-  // Options that we acknowledge but don't actually implement
-  // (WebSocket connections handle timeouts differently)
-  const isIgnorable = level === SOL_SOCKET && (optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-  if (!isForwardable && !isIgnorable) {
+  if (!isForwardable) {
     console.warn(`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`);
     return -1;
-  }
-  // For ignorable options, just return success
-  if (isIgnorable) {
-    return 0;
   }
   const ws = PHPWASM.getAllWebSockets(socketd)[0];
   if (!ws) {

--- a/packages/php-wasm/node-builds/8-0/asyncify/php_8_0.js
+++ b/packages/php-wasm/node-builds/8-0/asyncify/php_8_0.js
@@ -6673,6 +6673,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](
@@ -6806,42 +6829,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			// Wait for the connection to be established
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
-			// 30 second timeout
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);
@@ -10193,7 +10247,15 @@ export function init(RuntimeName, PHPLoader) {
 
 	var _wasm_recv = function (sockfd, buffer, size, flags) {
 		return Asyncify.handleSleep((wakeUp) => {
+			const receiveTimeout =
+				PHPWASM.socketTimeouts.get(sockfd)?.receive;
+			const startedAt = Date.now();
+			let resolved = false;
+
 			const poll = function () {
+				if (resolved) {
+					return;
+				}
 				let newl = ___syscall_recvfrom(
 					sockfd,
 					buffer,
@@ -10203,10 +10265,20 @@ export function init(RuntimeName, PHPLoader) {
 					null
 				);
 				if (newl > 0) {
+					resolved = true;
 					wakeUp(newl);
-				} else if (newl === -6) {
+				} else if (newl === -ERRNO_CODES.EAGAIN) {
+					if (
+						receiveTimeout > 0 &&
+						Date.now() - startedAt >= receiveTimeout
+					) {
+						resolved = true;
+						wakeUp(-ERRNO_CODES.EAGAIN);
+						return;
+					}
 					setTimeout(poll, 20);
 				} else {
+					resolved = true;
 					wakeUp(0);
 				}
 			};

--- a/packages/php-wasm/node-builds/8-0/asyncify/php_8_0.js
+++ b/packages/php-wasm/node-builds/8-0/asyncify/php_8_0.js
@@ -6243,6 +6243,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			// TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
 			if (PHPLoader.bindUserSpace) {
@@ -6720,6 +6721,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			// This implementation only supports websockets at the moment
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
@@ -6805,7 +6807,7 @@ export function init(RuntimeName, PHPLoader) {
 				return;
 			}
 			// Wait for the connection to be established
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			// 30 second timeout
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
@@ -9800,24 +9802,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
-		// Options that we can forward to the WebSocket proxy
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		// Options that we acknowledge but don't actually implement
-		// (WebSocket connections handle timeouts differently)
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		// For ignorable options, just return success
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/node-builds/8-0/jspi/php_8_0.js
+++ b/packages/php-wasm/node-builds/8-0/jspi/php_8_0.js
@@ -5949,42 +5949,73 @@ function _wasm_connect(sockfd, addr, addrlen) {
       wakeUp(-ERRNO_CODES.ECONNREFUSED);
       return;
     }
-    // Wait for the connection to be established
-    const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
-    // 30 second timeout
+    // Wait for the connection to be established. A zero timeval
+    // disables the timeout, matching SO_SNDTIMEO semantics.
+    const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+    const timeout = sendTimeout ?? 3e4;
     let resolved = false;
-    const timeoutId = setTimeout(() => {
-      if (!resolved) {
-        resolved = true;
-        wakeUp(-ERRNO_CODES.ETIMEDOUT);
-      }
-    }, timeout);
-    const handleOpen = () => {
-      if (!resolved) {
-        resolved = true;
+    let timeoutId;
+    let handleOpen;
+    let handleError;
+    let handleClose;
+    const peer = PHPWASM.getAllPeers(sock).find(
+      (candidate) => candidate.socket === ws
+    );
+
+    const cleanupConnectListeners = () => {
+      if (typeof timeoutId !== "undefined") {
         clearTimeout(timeoutId);
-        ws.removeEventListener("error", handleError);
-        ws.removeEventListener("close", handleClose);
-        wakeUp(0);
+      }
+      ws.removeEventListener("open", handleOpen);
+      ws.removeEventListener("error", handleError);
+      ws.removeEventListener("close", handleClose);
+    };
+
+    const cleanupFailedConnect = (errno) => {
+      try {
+        if (
+          ws.readyState !== ws.CLOSING &&
+          ws.readyState !== ws.CLOSED
+        ) {
+          ws.close();
+        }
+      } catch (e) {
+        // Ignore close errors on an already-failed connect.
+      }
+      if (peer) {
+        SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+      }
+      sock.connecting = false;
+      sock.error = errno;
+    };
+
+    const finishConnect = (result) => {
+      if (!resolved) {
+        resolved = true;
+        cleanupConnectListeners();
+        if (result < 0) {
+          cleanupFailedConnect(-result);
+        }
+        wakeUp(result);
       }
     };
-    const handleError = () => {
-      if (!resolved) {
-        resolved = true;
-        clearTimeout(timeoutId);
-        ws.removeEventListener("open", handleOpen);
-        ws.removeEventListener("close", handleClose);
-        wakeUp(-ERRNO_CODES.ECONNREFUSED);
-      }
+
+    if (timeout > 0) {
+      timeoutId = setTimeout(() => {
+        finishConnect(-ERRNO_CODES.ETIMEDOUT);
+      }, timeout);
+    }
+
+    handleOpen = () => {
+      finishConnect(0);
     };
-    const handleClose = () => {
-      if (!resolved) {
-        resolved = true;
-        clearTimeout(timeoutId);
-        ws.removeEventListener("open", handleOpen);
-        ws.removeEventListener("error", handleError);
-        wakeUp(-ERRNO_CODES.ECONNREFUSED);
-      }
+
+    handleError = () => {
+      finishConnect(-ERRNO_CODES.ECONNREFUSED);
+    };
+
+    handleClose = () => {
+      finishConnect(-ERRNO_CODES.ECONNREFUSED);
     };
     ws.addEventListener("open", handleOpen);
     ws.addEventListener("error", handleError);
@@ -8884,13 +8915,26 @@ var FS_createDevice = (...args) => FS.createDevice(...args);
 
 var _wasm_recv = function(sockfd, buffer, size, flags) {
   return Asyncify.handleSleep(wakeUp => {
+    const receiveTimeout = PHPWASM.socketTimeouts.get(sockfd)?.receive;
+    const startedAt = Date.now();
+    let resolved = false;
     const poll = function() {
+      if (resolved) {
+        return;
+      }
       let newl = ___syscall_recvfrom(sockfd, buffer, size, flags, null, null);
       if (newl > 0) {
+        resolved = true;
         wakeUp(newl);
-      } else if (newl === -6) {
+      } else if (newl === -ERRNO_CODES.EAGAIN) {
+        if (receiveTimeout > 0 && Date.now() - startedAt >= receiveTimeout) {
+          resolved = true;
+          wakeUp(-ERRNO_CODES.EAGAIN);
+          return;
+        }
         setTimeout(poll, 20);
       } else {
+        resolved = true;
         wakeUp(0);
       }
     };

--- a/packages/php-wasm/node-builds/8-0/jspi/php_8_0.js
+++ b/packages/php-wasm/node-builds/8-0/jspi/php_8_0.js
@@ -5411,6 +5411,7 @@ var PHPWASM = {
   O_NONBLOCK: 2048,
   POLLHUP: 16,
   SETFL_MASK: 3072,
+  socketTimeouts: new Map,
   init: function() {
     // TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
     if (PHPLoader.bindUserSpace) {
@@ -5807,6 +5808,24 @@ var PHPWASM = {
     return [ promise, cancel ];
   },
   noop: function() {},
+  parseSocketTimeout: function(optionValuePtr, optionLen) {
+    if (!optionValuePtr || optionLen < 8) {
+      return null;
+    }
+    let seconds;
+    let microseconds;
+    if (optionLen >= 16) {
+      seconds = Number(HEAP64[optionValuePtr >> 3]);
+      microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+    } else {
+      seconds = HEAP32[optionValuePtr >> 2];
+      microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+    }
+    if (!Number.isFinite(seconds) || !Number.isFinite(microseconds) || seconds < 0 || microseconds < 0) {
+      return null;
+    }
+    return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+  },
   spawnProcess: function(command, args, options) {
     if (Module["spawnProcess"]) {
       const spawned = Module["spawnProcess"](command, args, /**
@@ -5845,6 +5864,7 @@ var PHPWASM = {
     throw e;
   },
   shutdownSocket: function(socketd, how) {
+    PHPWASM.socketTimeouts.delete(socketd);
     // This implementation only supports websockets at the moment
     const sock = getSocketFromFD(socketd);
     const peer = Object.values(sock.peers)[0];
@@ -5930,7 +5950,7 @@ function _wasm_connect(sockfd, addr, addrlen) {
       return;
     }
     // Wait for the connection to be established
-    const timeout = 3e4;
+    const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
     // 30 second timeout
     let resolved = false;
     const timeoutId = setTimeout(() => {
@@ -8702,18 +8722,25 @@ function _wasm_setsockopt(socketd, level, optionName, optionValuePtr, optionLen)
   const SO_SNDTIMEO = 67;
   const IPPROTO_TCP = 6;
   const TCP_NODELAY = 1;
+  if (level === SOL_SOCKET && (optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)) {
+    const timeoutMs = PHPWASM.parseSocketTimeout(optionValuePtr, optionLen);
+    if (timeoutMs === null) {
+      return -1;
+    }
+    const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+    if (optionName === SO_RCVTIMEO) {
+      timeouts.receive = timeoutMs;
+    } else {
+      timeouts.send = timeoutMs;
+    }
+    PHPWASM.socketTimeouts.set(socketd, timeouts);
+    return 0;
+  }
   // Options that we can forward to the WebSocket proxy
   const isForwardable = (level === SOL_SOCKET && optionName === SO_KEEPALIVE) || (level === IPPROTO_TCP && optionName === TCP_NODELAY);
-  // Options that we acknowledge but don't actually implement
-  // (WebSocket connections handle timeouts differently)
-  const isIgnorable = level === SOL_SOCKET && (optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-  if (!isForwardable && !isIgnorable) {
+  if (!isForwardable) {
     console.warn(`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`);
     return -1;
-  }
-  // For ignorable options, just return success
-  if (isIgnorable) {
-    return 0;
   }
   const ws = PHPWASM.getAllWebSockets(socketd)[0];
   if (!ws) {

--- a/packages/php-wasm/node-builds/8-1/asyncify/php_8_1.js
+++ b/packages/php-wasm/node-builds/8-1/asyncify/php_8_1.js
@@ -6673,6 +6673,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](
@@ -6806,42 +6829,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			// Wait for the connection to be established
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
-			// 30 second timeout
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);
@@ -10211,7 +10265,15 @@ export function init(RuntimeName, PHPLoader) {
 
 	var _wasm_recv = function (sockfd, buffer, size, flags) {
 		return Asyncify.handleSleep((wakeUp) => {
+			const receiveTimeout =
+				PHPWASM.socketTimeouts.get(sockfd)?.receive;
+			const startedAt = Date.now();
+			let resolved = false;
+
 			const poll = function () {
+				if (resolved) {
+					return;
+				}
 				let newl = ___syscall_recvfrom(
 					sockfd,
 					buffer,
@@ -10221,10 +10283,20 @@ export function init(RuntimeName, PHPLoader) {
 					null
 				);
 				if (newl > 0) {
+					resolved = true;
 					wakeUp(newl);
-				} else if (newl === -6) {
+				} else if (newl === -ERRNO_CODES.EAGAIN) {
+					if (
+						receiveTimeout > 0 &&
+						Date.now() - startedAt >= receiveTimeout
+					) {
+						resolved = true;
+						wakeUp(-ERRNO_CODES.EAGAIN);
+						return;
+					}
 					setTimeout(poll, 20);
 				} else {
+					resolved = true;
 					wakeUp(0);
 				}
 			};

--- a/packages/php-wasm/node-builds/8-1/asyncify/php_8_1.js
+++ b/packages/php-wasm/node-builds/8-1/asyncify/php_8_1.js
@@ -6243,6 +6243,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			// TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
 			if (PHPLoader.bindUserSpace) {
@@ -6720,6 +6721,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			// This implementation only supports websockets at the moment
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
@@ -6805,7 +6807,7 @@ export function init(RuntimeName, PHPLoader) {
 				return;
 			}
 			// Wait for the connection to be established
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			// 30 second timeout
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
@@ -9818,24 +9820,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
-		// Options that we can forward to the WebSocket proxy
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		// Options that we acknowledge but don't actually implement
-		// (WebSocket connections handle timeouts differently)
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		// For ignorable options, just return success
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/node-builds/8-1/jspi/php_8_1.js
+++ b/packages/php-wasm/node-builds/8-1/jspi/php_8_1.js
@@ -5411,6 +5411,7 @@ var PHPWASM = {
   O_NONBLOCK: 2048,
   POLLHUP: 16,
   SETFL_MASK: 3072,
+  socketTimeouts: new Map,
   init: function() {
     // TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
     if (PHPLoader.bindUserSpace) {
@@ -5807,6 +5808,24 @@ var PHPWASM = {
     return [ promise, cancel ];
   },
   noop: function() {},
+  parseSocketTimeout: function(optionValuePtr, optionLen) {
+    if (!optionValuePtr || optionLen < 8) {
+      return null;
+    }
+    let seconds;
+    let microseconds;
+    if (optionLen >= 16) {
+      seconds = Number(HEAP64[optionValuePtr >> 3]);
+      microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+    } else {
+      seconds = HEAP32[optionValuePtr >> 2];
+      microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+    }
+    if (!Number.isFinite(seconds) || !Number.isFinite(microseconds) || seconds < 0 || microseconds < 0) {
+      return null;
+    }
+    return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+  },
   spawnProcess: function(command, args, options) {
     if (Module["spawnProcess"]) {
       const spawned = Module["spawnProcess"](command, args, /**
@@ -5845,6 +5864,7 @@ var PHPWASM = {
     throw e;
   },
   shutdownSocket: function(socketd, how) {
+    PHPWASM.socketTimeouts.delete(socketd);
     // This implementation only supports websockets at the moment
     const sock = getSocketFromFD(socketd);
     const peer = Object.values(sock.peers)[0];
@@ -5930,7 +5950,7 @@ function _wasm_connect(sockfd, addr, addrlen) {
       return;
     }
     // Wait for the connection to be established
-    const timeout = 3e4;
+    const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
     // 30 second timeout
     let resolved = false;
     const timeoutId = setTimeout(() => {
@@ -8720,18 +8740,25 @@ function _wasm_setsockopt(socketd, level, optionName, optionValuePtr, optionLen)
   const SO_SNDTIMEO = 67;
   const IPPROTO_TCP = 6;
   const TCP_NODELAY = 1;
+  if (level === SOL_SOCKET && (optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)) {
+    const timeoutMs = PHPWASM.parseSocketTimeout(optionValuePtr, optionLen);
+    if (timeoutMs === null) {
+      return -1;
+    }
+    const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+    if (optionName === SO_RCVTIMEO) {
+      timeouts.receive = timeoutMs;
+    } else {
+      timeouts.send = timeoutMs;
+    }
+    PHPWASM.socketTimeouts.set(socketd, timeouts);
+    return 0;
+  }
   // Options that we can forward to the WebSocket proxy
   const isForwardable = (level === SOL_SOCKET && optionName === SO_KEEPALIVE) || (level === IPPROTO_TCP && optionName === TCP_NODELAY);
-  // Options that we acknowledge but don't actually implement
-  // (WebSocket connections handle timeouts differently)
-  const isIgnorable = level === SOL_SOCKET && (optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-  if (!isForwardable && !isIgnorable) {
+  if (!isForwardable) {
     console.warn(`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`);
     return -1;
-  }
-  // For ignorable options, just return success
-  if (isIgnorable) {
-    return 0;
   }
   const ws = PHPWASM.getAllWebSockets(socketd)[0];
   if (!ws) {

--- a/packages/php-wasm/node-builds/8-1/jspi/php_8_1.js
+++ b/packages/php-wasm/node-builds/8-1/jspi/php_8_1.js
@@ -5949,42 +5949,73 @@ function _wasm_connect(sockfd, addr, addrlen) {
       wakeUp(-ERRNO_CODES.ECONNREFUSED);
       return;
     }
-    // Wait for the connection to be established
-    const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
-    // 30 second timeout
+    // Wait for the connection to be established. A zero timeval
+    // disables the timeout, matching SO_SNDTIMEO semantics.
+    const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+    const timeout = sendTimeout ?? 3e4;
     let resolved = false;
-    const timeoutId = setTimeout(() => {
-      if (!resolved) {
-        resolved = true;
-        wakeUp(-ERRNO_CODES.ETIMEDOUT);
-      }
-    }, timeout);
-    const handleOpen = () => {
-      if (!resolved) {
-        resolved = true;
+    let timeoutId;
+    let handleOpen;
+    let handleError;
+    let handleClose;
+    const peer = PHPWASM.getAllPeers(sock).find(
+      (candidate) => candidate.socket === ws
+    );
+
+    const cleanupConnectListeners = () => {
+      if (typeof timeoutId !== "undefined") {
         clearTimeout(timeoutId);
-        ws.removeEventListener("error", handleError);
-        ws.removeEventListener("close", handleClose);
-        wakeUp(0);
+      }
+      ws.removeEventListener("open", handleOpen);
+      ws.removeEventListener("error", handleError);
+      ws.removeEventListener("close", handleClose);
+    };
+
+    const cleanupFailedConnect = (errno) => {
+      try {
+        if (
+          ws.readyState !== ws.CLOSING &&
+          ws.readyState !== ws.CLOSED
+        ) {
+          ws.close();
+        }
+      } catch (e) {
+        // Ignore close errors on an already-failed connect.
+      }
+      if (peer) {
+        SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+      }
+      sock.connecting = false;
+      sock.error = errno;
+    };
+
+    const finishConnect = (result) => {
+      if (!resolved) {
+        resolved = true;
+        cleanupConnectListeners();
+        if (result < 0) {
+          cleanupFailedConnect(-result);
+        }
+        wakeUp(result);
       }
     };
-    const handleError = () => {
-      if (!resolved) {
-        resolved = true;
-        clearTimeout(timeoutId);
-        ws.removeEventListener("open", handleOpen);
-        ws.removeEventListener("close", handleClose);
-        wakeUp(-ERRNO_CODES.ECONNREFUSED);
-      }
+
+    if (timeout > 0) {
+      timeoutId = setTimeout(() => {
+        finishConnect(-ERRNO_CODES.ETIMEDOUT);
+      }, timeout);
+    }
+
+    handleOpen = () => {
+      finishConnect(0);
     };
-    const handleClose = () => {
-      if (!resolved) {
-        resolved = true;
-        clearTimeout(timeoutId);
-        ws.removeEventListener("open", handleOpen);
-        ws.removeEventListener("error", handleError);
-        wakeUp(-ERRNO_CODES.ECONNREFUSED);
-      }
+
+    handleError = () => {
+      finishConnect(-ERRNO_CODES.ECONNREFUSED);
+    };
+
+    handleClose = () => {
+      finishConnect(-ERRNO_CODES.ECONNREFUSED);
     };
     ws.addEventListener("open", handleOpen);
     ws.addEventListener("error", handleError);
@@ -8902,13 +8933,26 @@ var FS_createDevice = (...args) => FS.createDevice(...args);
 
 var _wasm_recv = function(sockfd, buffer, size, flags) {
   return Asyncify.handleSleep(wakeUp => {
+    const receiveTimeout = PHPWASM.socketTimeouts.get(sockfd)?.receive;
+    const startedAt = Date.now();
+    let resolved = false;
     const poll = function() {
+      if (resolved) {
+        return;
+      }
       let newl = ___syscall_recvfrom(sockfd, buffer, size, flags, null, null);
       if (newl > 0) {
+        resolved = true;
         wakeUp(newl);
-      } else if (newl === -6) {
+      } else if (newl === -ERRNO_CODES.EAGAIN) {
+        if (receiveTimeout > 0 && Date.now() - startedAt >= receiveTimeout) {
+          resolved = true;
+          wakeUp(-ERRNO_CODES.EAGAIN);
+          return;
+        }
         setTimeout(poll, 20);
       } else {
+        resolved = true;
         wakeUp(0);
       }
     };

--- a/packages/php-wasm/node-builds/8-2/asyncify/php_8_2.js
+++ b/packages/php-wasm/node-builds/8-2/asyncify/php_8_2.js
@@ -6243,6 +6243,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			// TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
 			if (PHPLoader.bindUserSpace) {
@@ -6720,6 +6721,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			// This implementation only supports websockets at the moment
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
@@ -6805,7 +6807,7 @@ export function init(RuntimeName, PHPLoader) {
 				return;
 			}
 			// Wait for the connection to be established
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			// 30 second timeout
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
@@ -9820,24 +9822,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
-		// Options that we can forward to the WebSocket proxy
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		// Options that we acknowledge but don't actually implement
-		// (WebSocket connections handle timeouts differently)
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		// For ignorable options, just return success
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/node-builds/8-2/asyncify/php_8_2.js
+++ b/packages/php-wasm/node-builds/8-2/asyncify/php_8_2.js
@@ -6673,6 +6673,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](
@@ -6806,42 +6829,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			// Wait for the connection to be established
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
-			// 30 second timeout
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);
@@ -10213,7 +10267,15 @@ export function init(RuntimeName, PHPLoader) {
 
 	var _wasm_recv = function (sockfd, buffer, size, flags) {
 		return Asyncify.handleSleep((wakeUp) => {
+			const receiveTimeout =
+				PHPWASM.socketTimeouts.get(sockfd)?.receive;
+			const startedAt = Date.now();
+			let resolved = false;
+
 			const poll = function () {
+				if (resolved) {
+					return;
+				}
 				let newl = ___syscall_recvfrom(
 					sockfd,
 					buffer,
@@ -10223,10 +10285,20 @@ export function init(RuntimeName, PHPLoader) {
 					null
 				);
 				if (newl > 0) {
+					resolved = true;
 					wakeUp(newl);
-				} else if (newl === -6) {
+				} else if (newl === -ERRNO_CODES.EAGAIN) {
+					if (
+						receiveTimeout > 0 &&
+						Date.now() - startedAt >= receiveTimeout
+					) {
+						resolved = true;
+						wakeUp(-ERRNO_CODES.EAGAIN);
+						return;
+					}
 					setTimeout(poll, 20);
 				} else {
+					resolved = true;
 					wakeUp(0);
 				}
 			};

--- a/packages/php-wasm/node-builds/8-2/jspi/php_8_2.js
+++ b/packages/php-wasm/node-builds/8-2/jspi/php_8_2.js
@@ -5949,42 +5949,73 @@ function _wasm_connect(sockfd, addr, addrlen) {
       wakeUp(-ERRNO_CODES.ECONNREFUSED);
       return;
     }
-    // Wait for the connection to be established
-    const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
-    // 30 second timeout
+    // Wait for the connection to be established. A zero timeval
+    // disables the timeout, matching SO_SNDTIMEO semantics.
+    const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+    const timeout = sendTimeout ?? 3e4;
     let resolved = false;
-    const timeoutId = setTimeout(() => {
-      if (!resolved) {
-        resolved = true;
-        wakeUp(-ERRNO_CODES.ETIMEDOUT);
-      }
-    }, timeout);
-    const handleOpen = () => {
-      if (!resolved) {
-        resolved = true;
+    let timeoutId;
+    let handleOpen;
+    let handleError;
+    let handleClose;
+    const peer = PHPWASM.getAllPeers(sock).find(
+      (candidate) => candidate.socket === ws
+    );
+
+    const cleanupConnectListeners = () => {
+      if (typeof timeoutId !== "undefined") {
         clearTimeout(timeoutId);
-        ws.removeEventListener("error", handleError);
-        ws.removeEventListener("close", handleClose);
-        wakeUp(0);
+      }
+      ws.removeEventListener("open", handleOpen);
+      ws.removeEventListener("error", handleError);
+      ws.removeEventListener("close", handleClose);
+    };
+
+    const cleanupFailedConnect = (errno) => {
+      try {
+        if (
+          ws.readyState !== ws.CLOSING &&
+          ws.readyState !== ws.CLOSED
+        ) {
+          ws.close();
+        }
+      } catch (e) {
+        // Ignore close errors on an already-failed connect.
+      }
+      if (peer) {
+        SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+      }
+      sock.connecting = false;
+      sock.error = errno;
+    };
+
+    const finishConnect = (result) => {
+      if (!resolved) {
+        resolved = true;
+        cleanupConnectListeners();
+        if (result < 0) {
+          cleanupFailedConnect(-result);
+        }
+        wakeUp(result);
       }
     };
-    const handleError = () => {
-      if (!resolved) {
-        resolved = true;
-        clearTimeout(timeoutId);
-        ws.removeEventListener("open", handleOpen);
-        ws.removeEventListener("close", handleClose);
-        wakeUp(-ERRNO_CODES.ECONNREFUSED);
-      }
+
+    if (timeout > 0) {
+      timeoutId = setTimeout(() => {
+        finishConnect(-ERRNO_CODES.ETIMEDOUT);
+      }, timeout);
+    }
+
+    handleOpen = () => {
+      finishConnect(0);
     };
-    const handleClose = () => {
-      if (!resolved) {
-        resolved = true;
-        clearTimeout(timeoutId);
-        ws.removeEventListener("open", handleOpen);
-        ws.removeEventListener("error", handleError);
-        wakeUp(-ERRNO_CODES.ECONNREFUSED);
-      }
+
+    handleError = () => {
+      finishConnect(-ERRNO_CODES.ECONNREFUSED);
+    };
+
+    handleClose = () => {
+      finishConnect(-ERRNO_CODES.ECONNREFUSED);
     };
     ws.addEventListener("open", handleOpen);
     ws.addEventListener("error", handleError);
@@ -8904,13 +8935,26 @@ var FS_createDevice = (...args) => FS.createDevice(...args);
 
 var _wasm_recv = function(sockfd, buffer, size, flags) {
   return Asyncify.handleSleep(wakeUp => {
+    const receiveTimeout = PHPWASM.socketTimeouts.get(sockfd)?.receive;
+    const startedAt = Date.now();
+    let resolved = false;
     const poll = function() {
+      if (resolved) {
+        return;
+      }
       let newl = ___syscall_recvfrom(sockfd, buffer, size, flags, null, null);
       if (newl > 0) {
+        resolved = true;
         wakeUp(newl);
-      } else if (newl === -6) {
+      } else if (newl === -ERRNO_CODES.EAGAIN) {
+        if (receiveTimeout > 0 && Date.now() - startedAt >= receiveTimeout) {
+          resolved = true;
+          wakeUp(-ERRNO_CODES.EAGAIN);
+          return;
+        }
         setTimeout(poll, 20);
       } else {
+        resolved = true;
         wakeUp(0);
       }
     };

--- a/packages/php-wasm/node-builds/8-2/jspi/php_8_2.js
+++ b/packages/php-wasm/node-builds/8-2/jspi/php_8_2.js
@@ -5411,6 +5411,7 @@ var PHPWASM = {
   O_NONBLOCK: 2048,
   POLLHUP: 16,
   SETFL_MASK: 3072,
+  socketTimeouts: new Map,
   init: function() {
     // TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
     if (PHPLoader.bindUserSpace) {
@@ -5807,6 +5808,24 @@ var PHPWASM = {
     return [ promise, cancel ];
   },
   noop: function() {},
+  parseSocketTimeout: function(optionValuePtr, optionLen) {
+    if (!optionValuePtr || optionLen < 8) {
+      return null;
+    }
+    let seconds;
+    let microseconds;
+    if (optionLen >= 16) {
+      seconds = Number(HEAP64[optionValuePtr >> 3]);
+      microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+    } else {
+      seconds = HEAP32[optionValuePtr >> 2];
+      microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+    }
+    if (!Number.isFinite(seconds) || !Number.isFinite(microseconds) || seconds < 0 || microseconds < 0) {
+      return null;
+    }
+    return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+  },
   spawnProcess: function(command, args, options) {
     if (Module["spawnProcess"]) {
       const spawned = Module["spawnProcess"](command, args, /**
@@ -5845,6 +5864,7 @@ var PHPWASM = {
     throw e;
   },
   shutdownSocket: function(socketd, how) {
+    PHPWASM.socketTimeouts.delete(socketd);
     // This implementation only supports websockets at the moment
     const sock = getSocketFromFD(socketd);
     const peer = Object.values(sock.peers)[0];
@@ -5930,7 +5950,7 @@ function _wasm_connect(sockfd, addr, addrlen) {
       return;
     }
     // Wait for the connection to be established
-    const timeout = 3e4;
+    const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
     // 30 second timeout
     let resolved = false;
     const timeoutId = setTimeout(() => {
@@ -8722,18 +8742,25 @@ function _wasm_setsockopt(socketd, level, optionName, optionValuePtr, optionLen)
   const SO_SNDTIMEO = 67;
   const IPPROTO_TCP = 6;
   const TCP_NODELAY = 1;
+  if (level === SOL_SOCKET && (optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)) {
+    const timeoutMs = PHPWASM.parseSocketTimeout(optionValuePtr, optionLen);
+    if (timeoutMs === null) {
+      return -1;
+    }
+    const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+    if (optionName === SO_RCVTIMEO) {
+      timeouts.receive = timeoutMs;
+    } else {
+      timeouts.send = timeoutMs;
+    }
+    PHPWASM.socketTimeouts.set(socketd, timeouts);
+    return 0;
+  }
   // Options that we can forward to the WebSocket proxy
   const isForwardable = (level === SOL_SOCKET && optionName === SO_KEEPALIVE) || (level === IPPROTO_TCP && optionName === TCP_NODELAY);
-  // Options that we acknowledge but don't actually implement
-  // (WebSocket connections handle timeouts differently)
-  const isIgnorable = level === SOL_SOCKET && (optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-  if (!isForwardable && !isIgnorable) {
+  if (!isForwardable) {
     console.warn(`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`);
     return -1;
-  }
-  // For ignorable options, just return success
-  if (isIgnorable) {
-    return 0;
   }
   const ws = PHPWASM.getAllWebSockets(socketd)[0];
   if (!ws) {

--- a/packages/php-wasm/node-builds/8-3/asyncify/php_8_3.js
+++ b/packages/php-wasm/node-builds/8-3/asyncify/php_8_3.js
@@ -6243,6 +6243,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			// TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
 			if (PHPLoader.bindUserSpace) {
@@ -6720,6 +6721,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			// This implementation only supports websockets at the moment
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
@@ -6805,7 +6807,7 @@ export function init(RuntimeName, PHPLoader) {
 				return;
 			}
 			// Wait for the connection to be established
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			// 30 second timeout
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
@@ -9820,24 +9822,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
-		// Options that we can forward to the WebSocket proxy
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		// Options that we acknowledge but don't actually implement
-		// (WebSocket connections handle timeouts differently)
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		// For ignorable options, just return success
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/node-builds/8-3/asyncify/php_8_3.js
+++ b/packages/php-wasm/node-builds/8-3/asyncify/php_8_3.js
@@ -6673,6 +6673,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](
@@ -6806,42 +6829,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			// Wait for the connection to be established
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
-			// 30 second timeout
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);
@@ -10213,7 +10267,15 @@ export function init(RuntimeName, PHPLoader) {
 
 	var _wasm_recv = function (sockfd, buffer, size, flags) {
 		return Asyncify.handleSleep((wakeUp) => {
+			const receiveTimeout =
+				PHPWASM.socketTimeouts.get(sockfd)?.receive;
+			const startedAt = Date.now();
+			let resolved = false;
+
 			const poll = function () {
+				if (resolved) {
+					return;
+				}
 				let newl = ___syscall_recvfrom(
 					sockfd,
 					buffer,
@@ -10223,10 +10285,20 @@ export function init(RuntimeName, PHPLoader) {
 					null
 				);
 				if (newl > 0) {
+					resolved = true;
 					wakeUp(newl);
-				} else if (newl === -6) {
+				} else if (newl === -ERRNO_CODES.EAGAIN) {
+					if (
+						receiveTimeout > 0 &&
+						Date.now() - startedAt >= receiveTimeout
+					) {
+						resolved = true;
+						wakeUp(-ERRNO_CODES.EAGAIN);
+						return;
+					}
 					setTimeout(poll, 20);
 				} else {
+					resolved = true;
 					wakeUp(0);
 				}
 			};

--- a/packages/php-wasm/node-builds/8-3/jspi/php_8_3.js
+++ b/packages/php-wasm/node-builds/8-3/jspi/php_8_3.js
@@ -5949,42 +5949,73 @@ function _wasm_connect(sockfd, addr, addrlen) {
       wakeUp(-ERRNO_CODES.ECONNREFUSED);
       return;
     }
-    // Wait for the connection to be established
-    const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
-    // 30 second timeout
+    // Wait for the connection to be established. A zero timeval
+    // disables the timeout, matching SO_SNDTIMEO semantics.
+    const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+    const timeout = sendTimeout ?? 3e4;
     let resolved = false;
-    const timeoutId = setTimeout(() => {
-      if (!resolved) {
-        resolved = true;
-        wakeUp(-ERRNO_CODES.ETIMEDOUT);
-      }
-    }, timeout);
-    const handleOpen = () => {
-      if (!resolved) {
-        resolved = true;
+    let timeoutId;
+    let handleOpen;
+    let handleError;
+    let handleClose;
+    const peer = PHPWASM.getAllPeers(sock).find(
+      (candidate) => candidate.socket === ws
+    );
+
+    const cleanupConnectListeners = () => {
+      if (typeof timeoutId !== "undefined") {
         clearTimeout(timeoutId);
-        ws.removeEventListener("error", handleError);
-        ws.removeEventListener("close", handleClose);
-        wakeUp(0);
+      }
+      ws.removeEventListener("open", handleOpen);
+      ws.removeEventListener("error", handleError);
+      ws.removeEventListener("close", handleClose);
+    };
+
+    const cleanupFailedConnect = (errno) => {
+      try {
+        if (
+          ws.readyState !== ws.CLOSING &&
+          ws.readyState !== ws.CLOSED
+        ) {
+          ws.close();
+        }
+      } catch (e) {
+        // Ignore close errors on an already-failed connect.
+      }
+      if (peer) {
+        SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+      }
+      sock.connecting = false;
+      sock.error = errno;
+    };
+
+    const finishConnect = (result) => {
+      if (!resolved) {
+        resolved = true;
+        cleanupConnectListeners();
+        if (result < 0) {
+          cleanupFailedConnect(-result);
+        }
+        wakeUp(result);
       }
     };
-    const handleError = () => {
-      if (!resolved) {
-        resolved = true;
-        clearTimeout(timeoutId);
-        ws.removeEventListener("open", handleOpen);
-        ws.removeEventListener("close", handleClose);
-        wakeUp(-ERRNO_CODES.ECONNREFUSED);
-      }
+
+    if (timeout > 0) {
+      timeoutId = setTimeout(() => {
+        finishConnect(-ERRNO_CODES.ETIMEDOUT);
+      }, timeout);
+    }
+
+    handleOpen = () => {
+      finishConnect(0);
     };
-    const handleClose = () => {
-      if (!resolved) {
-        resolved = true;
-        clearTimeout(timeoutId);
-        ws.removeEventListener("open", handleOpen);
-        ws.removeEventListener("error", handleError);
-        wakeUp(-ERRNO_CODES.ECONNREFUSED);
-      }
+
+    handleError = () => {
+      finishConnect(-ERRNO_CODES.ECONNREFUSED);
+    };
+
+    handleClose = () => {
+      finishConnect(-ERRNO_CODES.ECONNREFUSED);
     };
     ws.addEventListener("open", handleOpen);
     ws.addEventListener("error", handleError);
@@ -8904,13 +8935,26 @@ var FS_createDevice = (...args) => FS.createDevice(...args);
 
 var _wasm_recv = function(sockfd, buffer, size, flags) {
   return Asyncify.handleSleep(wakeUp => {
+    const receiveTimeout = PHPWASM.socketTimeouts.get(sockfd)?.receive;
+    const startedAt = Date.now();
+    let resolved = false;
     const poll = function() {
+      if (resolved) {
+        return;
+      }
       let newl = ___syscall_recvfrom(sockfd, buffer, size, flags, null, null);
       if (newl > 0) {
+        resolved = true;
         wakeUp(newl);
-      } else if (newl === -6) {
+      } else if (newl === -ERRNO_CODES.EAGAIN) {
+        if (receiveTimeout > 0 && Date.now() - startedAt >= receiveTimeout) {
+          resolved = true;
+          wakeUp(-ERRNO_CODES.EAGAIN);
+          return;
+        }
         setTimeout(poll, 20);
       } else {
+        resolved = true;
         wakeUp(0);
       }
     };

--- a/packages/php-wasm/node-builds/8-3/jspi/php_8_3.js
+++ b/packages/php-wasm/node-builds/8-3/jspi/php_8_3.js
@@ -5411,6 +5411,7 @@ var PHPWASM = {
   O_NONBLOCK: 2048,
   POLLHUP: 16,
   SETFL_MASK: 3072,
+  socketTimeouts: new Map,
   init: function() {
     // TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
     if (PHPLoader.bindUserSpace) {
@@ -5807,6 +5808,24 @@ var PHPWASM = {
     return [ promise, cancel ];
   },
   noop: function() {},
+  parseSocketTimeout: function(optionValuePtr, optionLen) {
+    if (!optionValuePtr || optionLen < 8) {
+      return null;
+    }
+    let seconds;
+    let microseconds;
+    if (optionLen >= 16) {
+      seconds = Number(HEAP64[optionValuePtr >> 3]);
+      microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+    } else {
+      seconds = HEAP32[optionValuePtr >> 2];
+      microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+    }
+    if (!Number.isFinite(seconds) || !Number.isFinite(microseconds) || seconds < 0 || microseconds < 0) {
+      return null;
+    }
+    return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+  },
   spawnProcess: function(command, args, options) {
     if (Module["spawnProcess"]) {
       const spawned = Module["spawnProcess"](command, args, /**
@@ -5845,6 +5864,7 @@ var PHPWASM = {
     throw e;
   },
   shutdownSocket: function(socketd, how) {
+    PHPWASM.socketTimeouts.delete(socketd);
     // This implementation only supports websockets at the moment
     const sock = getSocketFromFD(socketd);
     const peer = Object.values(sock.peers)[0];
@@ -5930,7 +5950,7 @@ function _wasm_connect(sockfd, addr, addrlen) {
       return;
     }
     // Wait for the connection to be established
-    const timeout = 3e4;
+    const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
     // 30 second timeout
     let resolved = false;
     const timeoutId = setTimeout(() => {
@@ -8722,18 +8742,25 @@ function _wasm_setsockopt(socketd, level, optionName, optionValuePtr, optionLen)
   const SO_SNDTIMEO = 67;
   const IPPROTO_TCP = 6;
   const TCP_NODELAY = 1;
+  if (level === SOL_SOCKET && (optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)) {
+    const timeoutMs = PHPWASM.parseSocketTimeout(optionValuePtr, optionLen);
+    if (timeoutMs === null) {
+      return -1;
+    }
+    const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+    if (optionName === SO_RCVTIMEO) {
+      timeouts.receive = timeoutMs;
+    } else {
+      timeouts.send = timeoutMs;
+    }
+    PHPWASM.socketTimeouts.set(socketd, timeouts);
+    return 0;
+  }
   // Options that we can forward to the WebSocket proxy
   const isForwardable = (level === SOL_SOCKET && optionName === SO_KEEPALIVE) || (level === IPPROTO_TCP && optionName === TCP_NODELAY);
-  // Options that we acknowledge but don't actually implement
-  // (WebSocket connections handle timeouts differently)
-  const isIgnorable = level === SOL_SOCKET && (optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-  if (!isForwardable && !isIgnorable) {
+  if (!isForwardable) {
     console.warn(`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`);
     return -1;
-  }
-  // For ignorable options, just return success
-  if (isIgnorable) {
-    return 0;
   }
   const ws = PHPWASM.getAllWebSockets(socketd)[0];
   if (!ws) {

--- a/packages/php-wasm/node-builds/8-4/asyncify/php_8_4.js
+++ b/packages/php-wasm/node-builds/8-4/asyncify/php_8_4.js
@@ -6243,6 +6243,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			// TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
 			if (PHPLoader.bindUserSpace) {
@@ -6720,6 +6721,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			// This implementation only supports websockets at the moment
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
@@ -6805,7 +6807,7 @@ export function init(RuntimeName, PHPLoader) {
 				return;
 			}
 			// Wait for the connection to be established
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			// 30 second timeout
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
@@ -9820,24 +9822,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
-		// Options that we can forward to the WebSocket proxy
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		// Options that we acknowledge but don't actually implement
-		// (WebSocket connections handle timeouts differently)
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		// For ignorable options, just return success
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/node-builds/8-4/asyncify/php_8_4.js
+++ b/packages/php-wasm/node-builds/8-4/asyncify/php_8_4.js
@@ -6673,6 +6673,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](
@@ -6806,42 +6829,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			// Wait for the connection to be established
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
-			// 30 second timeout
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);
@@ -10213,7 +10267,15 @@ export function init(RuntimeName, PHPLoader) {
 
 	var _wasm_recv = function (sockfd, buffer, size, flags) {
 		return Asyncify.handleSleep((wakeUp) => {
+			const receiveTimeout =
+				PHPWASM.socketTimeouts.get(sockfd)?.receive;
+			const startedAt = Date.now();
+			let resolved = false;
+
 			const poll = function () {
+				if (resolved) {
+					return;
+				}
 				let newl = ___syscall_recvfrom(
 					sockfd,
 					buffer,
@@ -10223,10 +10285,20 @@ export function init(RuntimeName, PHPLoader) {
 					null
 				);
 				if (newl > 0) {
+					resolved = true;
 					wakeUp(newl);
-				} else if (newl === -6) {
+				} else if (newl === -ERRNO_CODES.EAGAIN) {
+					if (
+						receiveTimeout > 0 &&
+						Date.now() - startedAt >= receiveTimeout
+					) {
+						resolved = true;
+						wakeUp(-ERRNO_CODES.EAGAIN);
+						return;
+					}
 					setTimeout(poll, 20);
 				} else {
+					resolved = true;
 					wakeUp(0);
 				}
 			};

--- a/packages/php-wasm/node-builds/8-4/jspi/php_8_4.js
+++ b/packages/php-wasm/node-builds/8-4/jspi/php_8_4.js
@@ -5949,42 +5949,73 @@ function _wasm_connect(sockfd, addr, addrlen) {
       wakeUp(-ERRNO_CODES.ECONNREFUSED);
       return;
     }
-    // Wait for the connection to be established
-    const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
-    // 30 second timeout
+    // Wait for the connection to be established. A zero timeval
+    // disables the timeout, matching SO_SNDTIMEO semantics.
+    const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+    const timeout = sendTimeout ?? 3e4;
     let resolved = false;
-    const timeoutId = setTimeout(() => {
-      if (!resolved) {
-        resolved = true;
-        wakeUp(-ERRNO_CODES.ETIMEDOUT);
-      }
-    }, timeout);
-    const handleOpen = () => {
-      if (!resolved) {
-        resolved = true;
+    let timeoutId;
+    let handleOpen;
+    let handleError;
+    let handleClose;
+    const peer = PHPWASM.getAllPeers(sock).find(
+      (candidate) => candidate.socket === ws
+    );
+
+    const cleanupConnectListeners = () => {
+      if (typeof timeoutId !== "undefined") {
         clearTimeout(timeoutId);
-        ws.removeEventListener("error", handleError);
-        ws.removeEventListener("close", handleClose);
-        wakeUp(0);
+      }
+      ws.removeEventListener("open", handleOpen);
+      ws.removeEventListener("error", handleError);
+      ws.removeEventListener("close", handleClose);
+    };
+
+    const cleanupFailedConnect = (errno) => {
+      try {
+        if (
+          ws.readyState !== ws.CLOSING &&
+          ws.readyState !== ws.CLOSED
+        ) {
+          ws.close();
+        }
+      } catch (e) {
+        // Ignore close errors on an already-failed connect.
+      }
+      if (peer) {
+        SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+      }
+      sock.connecting = false;
+      sock.error = errno;
+    };
+
+    const finishConnect = (result) => {
+      if (!resolved) {
+        resolved = true;
+        cleanupConnectListeners();
+        if (result < 0) {
+          cleanupFailedConnect(-result);
+        }
+        wakeUp(result);
       }
     };
-    const handleError = () => {
-      if (!resolved) {
-        resolved = true;
-        clearTimeout(timeoutId);
-        ws.removeEventListener("open", handleOpen);
-        ws.removeEventListener("close", handleClose);
-        wakeUp(-ERRNO_CODES.ECONNREFUSED);
-      }
+
+    if (timeout > 0) {
+      timeoutId = setTimeout(() => {
+        finishConnect(-ERRNO_CODES.ETIMEDOUT);
+      }, timeout);
+    }
+
+    handleOpen = () => {
+      finishConnect(0);
     };
-    const handleClose = () => {
-      if (!resolved) {
-        resolved = true;
-        clearTimeout(timeoutId);
-        ws.removeEventListener("open", handleOpen);
-        ws.removeEventListener("error", handleError);
-        wakeUp(-ERRNO_CODES.ECONNREFUSED);
-      }
+
+    handleError = () => {
+      finishConnect(-ERRNO_CODES.ECONNREFUSED);
+    };
+
+    handleClose = () => {
+      finishConnect(-ERRNO_CODES.ECONNREFUSED);
     };
     ws.addEventListener("open", handleOpen);
     ws.addEventListener("error", handleError);
@@ -8904,13 +8935,26 @@ var FS_createDevice = (...args) => FS.createDevice(...args);
 
 var _wasm_recv = function(sockfd, buffer, size, flags) {
   return Asyncify.handleSleep(wakeUp => {
+    const receiveTimeout = PHPWASM.socketTimeouts.get(sockfd)?.receive;
+    const startedAt = Date.now();
+    let resolved = false;
     const poll = function() {
+      if (resolved) {
+        return;
+      }
       let newl = ___syscall_recvfrom(sockfd, buffer, size, flags, null, null);
       if (newl > 0) {
+        resolved = true;
         wakeUp(newl);
-      } else if (newl === -6) {
+      } else if (newl === -ERRNO_CODES.EAGAIN) {
+        if (receiveTimeout > 0 && Date.now() - startedAt >= receiveTimeout) {
+          resolved = true;
+          wakeUp(-ERRNO_CODES.EAGAIN);
+          return;
+        }
         setTimeout(poll, 20);
       } else {
+        resolved = true;
         wakeUp(0);
       }
     };

--- a/packages/php-wasm/node-builds/8-4/jspi/php_8_4.js
+++ b/packages/php-wasm/node-builds/8-4/jspi/php_8_4.js
@@ -5411,6 +5411,7 @@ var PHPWASM = {
   O_NONBLOCK: 2048,
   POLLHUP: 16,
   SETFL_MASK: 3072,
+  socketTimeouts: new Map,
   init: function() {
     // TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
     if (PHPLoader.bindUserSpace) {
@@ -5807,6 +5808,24 @@ var PHPWASM = {
     return [ promise, cancel ];
   },
   noop: function() {},
+  parseSocketTimeout: function(optionValuePtr, optionLen) {
+    if (!optionValuePtr || optionLen < 8) {
+      return null;
+    }
+    let seconds;
+    let microseconds;
+    if (optionLen >= 16) {
+      seconds = Number(HEAP64[optionValuePtr >> 3]);
+      microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+    } else {
+      seconds = HEAP32[optionValuePtr >> 2];
+      microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+    }
+    if (!Number.isFinite(seconds) || !Number.isFinite(microseconds) || seconds < 0 || microseconds < 0) {
+      return null;
+    }
+    return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+  },
   spawnProcess: function(command, args, options) {
     if (Module["spawnProcess"]) {
       const spawned = Module["spawnProcess"](command, args, /**
@@ -5845,6 +5864,7 @@ var PHPWASM = {
     throw e;
   },
   shutdownSocket: function(socketd, how) {
+    PHPWASM.socketTimeouts.delete(socketd);
     // This implementation only supports websockets at the moment
     const sock = getSocketFromFD(socketd);
     const peer = Object.values(sock.peers)[0];
@@ -5930,7 +5950,7 @@ function _wasm_connect(sockfd, addr, addrlen) {
       return;
     }
     // Wait for the connection to be established
-    const timeout = 3e4;
+    const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
     // 30 second timeout
     let resolved = false;
     const timeoutId = setTimeout(() => {
@@ -8722,18 +8742,25 @@ function _wasm_setsockopt(socketd, level, optionName, optionValuePtr, optionLen)
   const SO_SNDTIMEO = 67;
   const IPPROTO_TCP = 6;
   const TCP_NODELAY = 1;
+  if (level === SOL_SOCKET && (optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)) {
+    const timeoutMs = PHPWASM.parseSocketTimeout(optionValuePtr, optionLen);
+    if (timeoutMs === null) {
+      return -1;
+    }
+    const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+    if (optionName === SO_RCVTIMEO) {
+      timeouts.receive = timeoutMs;
+    } else {
+      timeouts.send = timeoutMs;
+    }
+    PHPWASM.socketTimeouts.set(socketd, timeouts);
+    return 0;
+  }
   // Options that we can forward to the WebSocket proxy
   const isForwardable = (level === SOL_SOCKET && optionName === SO_KEEPALIVE) || (level === IPPROTO_TCP && optionName === TCP_NODELAY);
-  // Options that we acknowledge but don't actually implement
-  // (WebSocket connections handle timeouts differently)
-  const isIgnorable = level === SOL_SOCKET && (optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-  if (!isForwardable && !isIgnorable) {
+  if (!isForwardable) {
     console.warn(`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`);
     return -1;
-  }
-  // For ignorable options, just return success
-  if (isIgnorable) {
-    return 0;
   }
   const ws = PHPWASM.getAllWebSockets(socketd)[0];
   if (!ws) {

--- a/packages/php-wasm/node-builds/8-5/asyncify/php_8_5.js
+++ b/packages/php-wasm/node-builds/8-5/asyncify/php_8_5.js
@@ -6243,6 +6243,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			// TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
 			if (PHPLoader.bindUserSpace) {
@@ -6720,6 +6721,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			// This implementation only supports websockets at the moment
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
@@ -6805,7 +6807,7 @@ export function init(RuntimeName, PHPLoader) {
 				return;
 			}
 			// Wait for the connection to be established
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			// 30 second timeout
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
@@ -9820,24 +9822,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
-		// Options that we can forward to the WebSocket proxy
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		// Options that we acknowledge but don't actually implement
-		// (WebSocket connections handle timeouts differently)
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		// For ignorable options, just return success
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/node-builds/8-5/asyncify/php_8_5.js
+++ b/packages/php-wasm/node-builds/8-5/asyncify/php_8_5.js
@@ -6673,6 +6673,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](
@@ -6806,42 +6829,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			// Wait for the connection to be established
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
-			// 30 second timeout
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);
@@ -10213,7 +10267,15 @@ export function init(RuntimeName, PHPLoader) {
 
 	var _wasm_recv = function (sockfd, buffer, size, flags) {
 		return Asyncify.handleSleep((wakeUp) => {
+			const receiveTimeout =
+				PHPWASM.socketTimeouts.get(sockfd)?.receive;
+			const startedAt = Date.now();
+			let resolved = false;
+
 			const poll = function () {
+				if (resolved) {
+					return;
+				}
 				let newl = ___syscall_recvfrom(
 					sockfd,
 					buffer,
@@ -10223,10 +10285,20 @@ export function init(RuntimeName, PHPLoader) {
 					null
 				);
 				if (newl > 0) {
+					resolved = true;
 					wakeUp(newl);
-				} else if (newl === -6) {
+				} else if (newl === -ERRNO_CODES.EAGAIN) {
+					if (
+						receiveTimeout > 0 &&
+						Date.now() - startedAt >= receiveTimeout
+					) {
+						resolved = true;
+						wakeUp(-ERRNO_CODES.EAGAIN);
+						return;
+					}
 					setTimeout(poll, 20);
 				} else {
+					resolved = true;
 					wakeUp(0);
 				}
 			};

--- a/packages/php-wasm/node-builds/8-5/jspi/php_8_5.js
+++ b/packages/php-wasm/node-builds/8-5/jspi/php_8_5.js
@@ -5949,41 +5949,73 @@ function _wasm_connect(sockfd, addr, addrlen) {
       wakeUp(-ERRNO_CODES.ECONNREFUSED);
       return;
     }
-    // Wait for the connection to be established
-    const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
+    // Wait for the connection to be established. A zero timeval
+    // disables the timeout, matching SO_SNDTIMEO semantics.
+    const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+    const timeout = sendTimeout ?? 3e4;
     let resolved = false;
-    const timeoutId = setTimeout(() => {
-      if (!resolved) {
-        resolved = true;
-        wakeUp(-ERRNO_CODES.ETIMEDOUT);
-      }
-    }, timeout);
-    const handleOpen = () => {
-      if (!resolved) {
-        resolved = true;
+    let timeoutId;
+    let handleOpen;
+    let handleError;
+    let handleClose;
+    const peer = PHPWASM.getAllPeers(sock).find(
+      (candidate) => candidate.socket === ws
+    );
+
+    const cleanupConnectListeners = () => {
+      if (typeof timeoutId !== "undefined") {
         clearTimeout(timeoutId);
-        ws.removeEventListener("error", handleError);
-        ws.removeEventListener("close", handleClose);
-        wakeUp(0);
+      }
+      ws.removeEventListener("open", handleOpen);
+      ws.removeEventListener("error", handleError);
+      ws.removeEventListener("close", handleClose);
+    };
+
+    const cleanupFailedConnect = (errno) => {
+      try {
+        if (
+          ws.readyState !== ws.CLOSING &&
+          ws.readyState !== ws.CLOSED
+        ) {
+          ws.close();
+        }
+      } catch (e) {
+        // Ignore close errors on an already-failed connect.
+      }
+      if (peer) {
+        SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+      }
+      sock.connecting = false;
+      sock.error = errno;
+    };
+
+    const finishConnect = (result) => {
+      if (!resolved) {
+        resolved = true;
+        cleanupConnectListeners();
+        if (result < 0) {
+          cleanupFailedConnect(-result);
+        }
+        wakeUp(result);
       }
     };
-    const handleError = () => {
-      if (!resolved) {
-        resolved = true;
-        clearTimeout(timeoutId);
-        ws.removeEventListener("open", handleOpen);
-        ws.removeEventListener("close", handleClose);
-        wakeUp(-ERRNO_CODES.ECONNREFUSED);
-      }
+
+    if (timeout > 0) {
+      timeoutId = setTimeout(() => {
+        finishConnect(-ERRNO_CODES.ETIMEDOUT);
+      }, timeout);
+    }
+
+    handleOpen = () => {
+      finishConnect(0);
     };
-    const handleClose = () => {
-      if (!resolved) {
-        resolved = true;
-        clearTimeout(timeoutId);
-        ws.removeEventListener("open", handleOpen);
-        ws.removeEventListener("error", handleError);
-        wakeUp(-ERRNO_CODES.ECONNREFUSED);
-      }
+
+    handleError = () => {
+      finishConnect(-ERRNO_CODES.ECONNREFUSED);
+    };
+
+    handleClose = () => {
+      finishConnect(-ERRNO_CODES.ECONNREFUSED);
     };
     ws.addEventListener("open", handleOpen);
     ws.addEventListener("error", handleError);
@@ -8903,13 +8935,26 @@ var FS_createDevice = (...args) => FS.createDevice(...args);
 
 var _wasm_recv = function(sockfd, buffer, size, flags) {
   return Asyncify.handleSleep(wakeUp => {
+    const receiveTimeout = PHPWASM.socketTimeouts.get(sockfd)?.receive;
+    const startedAt = Date.now();
+    let resolved = false;
     const poll = function() {
+      if (resolved) {
+        return;
+      }
       let newl = ___syscall_recvfrom(sockfd, buffer, size, flags, null, null);
       if (newl > 0) {
+        resolved = true;
         wakeUp(newl);
-      } else if (newl === -6) {
+      } else if (newl === -ERRNO_CODES.EAGAIN) {
+        if (receiveTimeout > 0 && Date.now() - startedAt >= receiveTimeout) {
+          resolved = true;
+          wakeUp(-ERRNO_CODES.EAGAIN);
+          return;
+        }
         setTimeout(poll, 20);
       } else {
+        resolved = true;
         wakeUp(0);
       }
     };

--- a/packages/php-wasm/node-builds/8-5/jspi/php_8_5.js
+++ b/packages/php-wasm/node-builds/8-5/jspi/php_8_5.js
@@ -5411,6 +5411,7 @@ var PHPWASM = {
   O_NONBLOCK: 2048,
   POLLHUP: 16,
   SETFL_MASK: 3072,
+  socketTimeouts: new Map,
   init: function() {
     // TODO: Move this to a library function that is made an onInit callback by the `__postset` suffix.
     if (PHPLoader.bindUserSpace) {
@@ -5807,6 +5808,24 @@ var PHPWASM = {
     return [ promise, cancel ];
   },
   noop: function() {},
+  parseSocketTimeout: function(optionValuePtr, optionLen) {
+    if (!optionValuePtr || optionLen < 8) {
+      return null;
+    }
+    let seconds;
+    let microseconds;
+    if (optionLen >= 16) {
+      seconds = Number(HEAP64[optionValuePtr >> 3]);
+      microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+    } else {
+      seconds = HEAP32[optionValuePtr >> 2];
+      microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+    }
+    if (!Number.isFinite(seconds) || !Number.isFinite(microseconds) || seconds < 0 || microseconds < 0) {
+      return null;
+    }
+    return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+  },
   spawnProcess: function(command, args, options) {
     if (Module["spawnProcess"]) {
       const spawned = Module["spawnProcess"](command, args, /**
@@ -5845,6 +5864,7 @@ var PHPWASM = {
     throw e;
   },
   shutdownSocket: function(socketd, how) {
+    PHPWASM.socketTimeouts.delete(socketd);
     // This implementation only supports websockets at the moment
     const sock = getSocketFromFD(socketd);
     const peer = Object.values(sock.peers)[0];
@@ -5930,8 +5950,7 @@ function _wasm_connect(sockfd, addr, addrlen) {
       return;
     }
     // Wait for the connection to be established
-    const timeout = 3e4;
-    // 30 second timeout
+    const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
     let resolved = false;
     const timeoutId = setTimeout(() => {
       if (!resolved) {
@@ -8722,18 +8741,25 @@ function _wasm_setsockopt(socketd, level, optionName, optionValuePtr, optionLen)
   const SO_SNDTIMEO = 67;
   const IPPROTO_TCP = 6;
   const TCP_NODELAY = 1;
+  if (level === SOL_SOCKET && (optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)) {
+    const timeoutMs = PHPWASM.parseSocketTimeout(optionValuePtr, optionLen);
+    if (timeoutMs === null) {
+      return -1;
+    }
+    const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+    if (optionName === SO_RCVTIMEO) {
+      timeouts.receive = timeoutMs;
+    } else {
+      timeouts.send = timeoutMs;
+    }
+    PHPWASM.socketTimeouts.set(socketd, timeouts);
+    return 0;
+  }
   // Options that we can forward to the WebSocket proxy
   const isForwardable = (level === SOL_SOCKET && optionName === SO_KEEPALIVE) || (level === IPPROTO_TCP && optionName === TCP_NODELAY);
-  // Options that we acknowledge but don't actually implement
-  // (WebSocket connections handle timeouts differently)
-  const isIgnorable = level === SOL_SOCKET && (optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-  if (!isForwardable && !isIgnorable) {
+  if (!isForwardable) {
     console.warn(`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`);
     return -1;
-  }
-  // For ignorable options, just return success
-  if (isIgnorable) {
-    return 0;
   }
   const ws = PHPWASM.getAllWebSockets(socketd)[0];
   if (!ws) {

--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -185,7 +185,8 @@
 					"php-imagick.spec.ts",
 					"php-soap.spec.ts",
 					"php-image-extensions.spec.ts",
-					"php-fsockopen.spec.ts"
+					"php-fsockopen.spec.ts",
+					"php-socket-timeouts.spec.ts"
 				]
 			}
 		},

--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -170,7 +170,8 @@
 					"php-imagick.spec.ts",
 					"php-soap.spec.ts",
 					"php-image-extensions.spec.ts",
-					"php-fsockopen.spec.ts"
+					"php-fsockopen.spec.ts",
+					"php-socket-timeouts.spec.ts"
 				]
 			}
 		},

--- a/packages/php-wasm/node/src/test/php-memcached.spec.ts
+++ b/packages/php-wasm/node/src/test/php-memcached.spec.ts
@@ -134,10 +134,10 @@ describe('Memcached Extension', () => {
 const createMemcachedPHP = (useBinaryProtocol = false) => `
 	function createMemcached() {
 		$m = new Memcached();
-		// Set timeouts to give WebSocket proxy time to connect
+		// Memcached send/receive timeouts are in microseconds.
 		$m->setOption(Memcached::OPT_CONNECT_TIMEOUT, 5000);
-		$m->setOption(Memcached::OPT_SEND_TIMEOUT, 5000);
-		$m->setOption(Memcached::OPT_RECV_TIMEOUT, 5000);
+		$m->setOption(Memcached::OPT_SEND_TIMEOUT, 5000000);
+		$m->setOption(Memcached::OPT_RECV_TIMEOUT, 5000000);
 		// Blocking mode for more reliable connections in WASM
 		$m->setOption(Memcached::OPT_NO_BLOCK, false);
 		${useBinaryProtocol ? '$m->setOption(Memcached::OPT_BINARY_PROTOCOL, true);' : ''}

--- a/packages/php-wasm/node/src/test/php-redis.spec.ts
+++ b/packages/php-wasm/node/src/test/php-redis.spec.ts
@@ -235,6 +235,63 @@ if (!isJspiAvailable) {
 				expect(result.errors).toBeFalsy();
 			});
 
+			it('honors a custom read timeout against a blocking Redis command', async () => {
+				const testKey = `test_read_timeout_${Date.now()}_${Math.random().toString(36).substring(7)}`;
+
+				const result = await php.run({
+					code: `<?php
+					$r = new Redis();
+					$r->connect('${REDIS_HOST}', ${REDIS_PORT}, 5.0);
+
+					if (!defined('Redis::OPT_READ_TIMEOUT')) {
+						echo json_encode([
+							'outcome' => 'MISSING_OPT_READ_TIMEOUT',
+						]);
+						exit;
+					}
+
+					$key = '${testKey}';
+					$r->del($key);
+					$r->setOption(Redis::OPT_READ_TIMEOUT, 0.2);
+
+					$start = microtime(true);
+					$outcome = 'UNKNOWN';
+					$error = null;
+
+					try {
+						$value = $r->blPop([$key], 2);
+						$outcome = $value === false ? 'FALSE' : 'VALUE';
+					} catch (Throwable $e) {
+						$outcome = 'EXCEPTION';
+						$error = $e->getMessage();
+					}
+
+					$elapsedMs = (int) round((microtime(true) - $start) * 1000);
+					$r->close();
+
+					echo json_encode([
+						'outcome' => $outcome,
+						'elapsedMs' => $elapsedMs,
+						'error' => $error,
+					]);
+				?>`,
+				});
+
+				const timeoutResult = JSON.parse(result.text) as {
+					outcome: string;
+					elapsedMs: number;
+					error: string | null;
+				};
+				expect(['EXCEPTION', 'FALSE']).toContain(timeoutResult.outcome);
+				expect(timeoutResult.elapsedMs).toBeGreaterThanOrEqual(100);
+				expect(timeoutResult.elapsedMs).toBeLessThan(1500);
+				if (timeoutResult.outcome === 'EXCEPTION') {
+					expect(timeoutResult.error).toMatch(
+						/read|socket|timed? out/i
+					);
+				}
+			});
+
 			it('can set values with expiration', async () => {
 				const testKey = `test_expiry_${Date.now()}_${Math.random().toString(36).substring(7)}`;
 

--- a/packages/php-wasm/node/src/test/php-socket-timeouts.spec.ts
+++ b/packages/php-wasm/node/src/test/php-socket-timeouts.spec.ts
@@ -36,7 +36,18 @@ describe('socket timeout support', () => {
 		expect(source).toContain(
 			'PHPWASM.socketTimeouts.set(socketd, timeouts)'
 		);
-		expect(source).toContain('PHPWASM.socketTimeouts.get(sockfd)?.send');
+		expect(source).toContain('const receiveTimeout =');
+		expect(source).toContain('PHPWASM.socketTimeouts.get(sockfd)?.receive');
+		expect(source).toContain('wakeUp(-ERRNO_CODES.EAGAIN)');
+		expect(source).toContain(
+			'const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send'
+		);
+		expect(source).toContain('const timeout = sendTimeout ?? 30000');
+		expect(source).toContain('const cleanupConnectListeners = () =>');
+		expect(source).toContain('const cleanupFailedConnect = (errno) =>');
+		expect(source).toContain('sock.connecting = false');
+		expect(source).toContain('sock.error = errno');
+		expect(source).not.toContain('?.send || 30000');
 		expect(source).not.toContain('const isIgnorable');
 	});
 
@@ -62,8 +73,27 @@ describe('socket timeout support', () => {
 				'PHPWASM.socketTimeouts.set(socketd, timeouts)'
 			);
 			expect(loader, loaderFile).toContain(
+				'parseSocketTimeout: function'
+			);
+			if (loader.includes('___syscall_recvfrom(sockfd')) {
+				expect(loader, loaderFile).toContain(
+					'PHPWASM.socketTimeouts.get(sockfd)?.receive'
+				);
+				expect(loader, loaderFile).toContain(
+					'wakeUp(-ERRNO_CODES.EAGAIN)'
+				);
+			}
+			expect(loader, loaderFile).toContain(
 				'PHPWASM.socketTimeouts.get(sockfd)?.send'
 			);
+			expect(loader, loaderFile).toContain(
+				'const timeout = sendTimeout ?? 3e4'
+			);
+			expect(loader, loaderFile).toContain('cleanupConnectListeners');
+			expect(loader, loaderFile).toContain('cleanupFailedConnect');
+			expect(loader, loaderFile).toContain('sock.connecting = false');
+			expect(loader, loaderFile).toContain('sock.error = errno');
+			expect(loader, loaderFile).not.toContain('?.send || 3e4');
 			expect(loader, loaderFile).not.toContain('isIgnorable');
 		}
 	});

--- a/packages/php-wasm/node/src/test/php-socket-timeouts.spec.ts
+++ b/packages/php-wasm/node/src/test/php-socket-timeouts.spec.ts
@@ -1,0 +1,70 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(
+	dirname(fileURLToPath(import.meta.url)),
+	'../../../../..'
+);
+
+function collectGeneratedPhpLoaders(directory: string): string[] {
+	return readdirSync(directory)
+		.flatMap((entry) => {
+			const fullPath = join(directory, entry);
+			if (statSync(fullPath).isDirectory()) {
+				return collectGeneratedPhpLoaders(fullPath);
+			}
+			return /php_\d+_\d+\.js$/.test(entry) ? [fullPath] : [];
+		})
+		.sort();
+}
+
+describe('socket timeout support', () => {
+	it('is present in the Emscripten library source', () => {
+		const source = readFileSync(
+			join(
+				repoRoot,
+				'packages/php-wasm/compile/php/phpwasm-emscripten-library.js'
+			),
+			'utf8'
+		);
+
+		expect(source).toContain('socketTimeouts: new Map()');
+		expect(source).toContain('parseSocketTimeout');
+		expect(source).toContain('SO_RCVTIMEO');
+		expect(source).toContain('SO_SNDTIMEO');
+		expect(source).toContain(
+			'PHPWASM.socketTimeouts.set(socketd, timeouts)'
+		);
+		expect(source).toContain('PHPWASM.socketTimeouts.get(sockfd)?.send');
+		expect(source).not.toContain('const isIgnorable');
+	});
+
+	it('is present in all checked-in generated PHP loaders', () => {
+		const loaderFiles = [
+			...collectGeneratedPhpLoaders(
+				join(repoRoot, 'packages/php-wasm/node-builds')
+			),
+			...collectGeneratedPhpLoaders(
+				join(repoRoot, 'packages/php-wasm/web-builds')
+			),
+		];
+
+		expect(loaderFiles).toHaveLength(32);
+
+		for (const loaderFile of loaderFiles) {
+			const loader = readFileSync(loaderFile, 'utf8');
+			expect(loader, loaderFile).toContain('socketTimeouts: new Map');
+			expect(loader, loaderFile).toContain('parseSocketTimeout');
+			expect(loader, loaderFile).toContain('SO_RCVTIMEO');
+			expect(loader, loaderFile).toContain('SO_SNDTIMEO');
+			expect(loader, loaderFile).toContain(
+				'PHPWASM.socketTimeouts.set(socketd, timeouts)'
+			);
+			expect(loader, loaderFile).toContain(
+				'PHPWASM.socketTimeouts.get(sockfd)?.send'
+			);
+			expect(loader, loaderFile).not.toContain('isIgnorable');
+		}
+	});
+});

--- a/packages/php-wasm/web-builds/5-2/asyncify/php_5_2.js
+++ b/packages/php-wasm/web-builds/5-2/asyncify/php_5_2.js
@@ -5201,40 +5201,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);

--- a/packages/php-wasm/web-builds/5-2/asyncify/php_5_2.js
+++ b/packages/php-wasm/web-builds/5-2/asyncify/php_5_2.js
@@ -4716,6 +4716,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -5079,6 +5080,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](command, args, {
@@ -5107,6 +5131,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
 			if (!peer) {
@@ -5176,7 +5201,7 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
 				if (!resolved) {
@@ -7448,20 +7473,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/web-builds/5-2/jspi/php_5_2.js
+++ b/packages/php-wasm/web-builds/5-2/jspi/php_5_2.js
@@ -5158,40 +5158,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);

--- a/packages/php-wasm/web-builds/5-2/jspi/php_5_2.js
+++ b/packages/php-wasm/web-builds/5-2/jspi/php_5_2.js
@@ -4673,6 +4673,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -5036,6 +5037,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](command, args, {
@@ -5064,6 +5088,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
 			if (!peer) {
@@ -5133,7 +5158,7 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
 				if (!resolved) {
@@ -7401,20 +7426,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {
@@ -7423,6 +7462,7 @@ export function init(RuntimeName, PHPLoader) {
 		ws.setSocketOpt(level, optionName, optionValuePtr);
 		return 0;
 	}
+
 	var Asyncify = {
 		instrumentWasmImports(imports) {
 			var importPattern =

--- a/packages/php-wasm/web-builds/7-4/asyncify/php_7_4.js
+++ b/packages/php-wasm/web-builds/7-4/asyncify/php_7_4.js
@@ -5281,40 +5281,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);

--- a/packages/php-wasm/web-builds/7-4/asyncify/php_7_4.js
+++ b/packages/php-wasm/web-builds/7-4/asyncify/php_7_4.js
@@ -4796,6 +4796,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -5159,6 +5160,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](command, args, {
@@ -5187,6 +5211,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
 			if (!peer) {
@@ -5256,7 +5281,7 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
 				if (!resolved) {
@@ -7650,20 +7675,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/web-builds/7-4/jspi/php_7_4.js
+++ b/packages/php-wasm/web-builds/7-4/jspi/php_7_4.js
@@ -5158,40 +5158,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);

--- a/packages/php-wasm/web-builds/7-4/jspi/php_7_4.js
+++ b/packages/php-wasm/web-builds/7-4/jspi/php_7_4.js
@@ -4673,6 +4673,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -5036,6 +5037,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](command, args, {
@@ -5064,6 +5088,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
 			if (!peer) {
@@ -5133,7 +5158,7 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
 				if (!resolved) {
@@ -7523,20 +7548,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/web-builds/8-0/asyncify/php_8_0.js
+++ b/packages/php-wasm/web-builds/8-0/asyncify/php_8_0.js
@@ -5281,40 +5281,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);

--- a/packages/php-wasm/web-builds/8-0/asyncify/php_8_0.js
+++ b/packages/php-wasm/web-builds/8-0/asyncify/php_8_0.js
@@ -4796,6 +4796,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -5159,6 +5160,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](command, args, {
@@ -5187,6 +5211,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
 			if (!peer) {
@@ -5256,7 +5281,7 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
 				if (!resolved) {
@@ -7650,20 +7675,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/web-builds/8-0/jspi/php_8_0.js
+++ b/packages/php-wasm/web-builds/8-0/jspi/php_8_0.js
@@ -5158,40 +5158,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);

--- a/packages/php-wasm/web-builds/8-0/jspi/php_8_0.js
+++ b/packages/php-wasm/web-builds/8-0/jspi/php_8_0.js
@@ -4673,6 +4673,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -5036,6 +5037,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](command, args, {
@@ -5064,6 +5088,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
 			if (!peer) {
@@ -5133,7 +5158,7 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
 				if (!resolved) {
@@ -7523,20 +7548,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/web-builds/8-1/asyncify/php_8_1.js
+++ b/packages/php-wasm/web-builds/8-1/asyncify/php_8_1.js
@@ -5281,40 +5281,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);

--- a/packages/php-wasm/web-builds/8-1/asyncify/php_8_1.js
+++ b/packages/php-wasm/web-builds/8-1/asyncify/php_8_1.js
@@ -4796,6 +4796,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -5159,6 +5160,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](command, args, {
@@ -5187,6 +5211,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
 			if (!peer) {
@@ -5256,7 +5281,7 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
 				if (!resolved) {
@@ -7663,20 +7688,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/web-builds/8-1/jspi/php_8_1.js
+++ b/packages/php-wasm/web-builds/8-1/jspi/php_8_1.js
@@ -5158,40 +5158,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);

--- a/packages/php-wasm/web-builds/8-1/jspi/php_8_1.js
+++ b/packages/php-wasm/web-builds/8-1/jspi/php_8_1.js
@@ -4673,6 +4673,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -5036,6 +5037,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](command, args, {
@@ -5064,6 +5088,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
 			if (!peer) {
@@ -5133,7 +5158,7 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
 				if (!resolved) {
@@ -7536,20 +7561,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/web-builds/8-2/asyncify/php_8_2.js
+++ b/packages/php-wasm/web-builds/8-2/asyncify/php_8_2.js
@@ -5281,40 +5281,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);

--- a/packages/php-wasm/web-builds/8-2/asyncify/php_8_2.js
+++ b/packages/php-wasm/web-builds/8-2/asyncify/php_8_2.js
@@ -4796,6 +4796,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -5159,6 +5160,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](command, args, {
@@ -5187,6 +5211,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
 			if (!peer) {
@@ -5256,7 +5281,7 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
 				if (!resolved) {
@@ -7664,20 +7689,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/web-builds/8-2/jspi/php_8_2.js
+++ b/packages/php-wasm/web-builds/8-2/jspi/php_8_2.js
@@ -4673,6 +4673,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -5036,6 +5037,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](command, args, {
@@ -5064,6 +5088,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
 			if (!peer) {
@@ -5133,7 +5158,7 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
 				if (!resolved) {
@@ -7537,20 +7562,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/web-builds/8-2/jspi/php_8_2.js
+++ b/packages/php-wasm/web-builds/8-2/jspi/php_8_2.js
@@ -5158,40 +5158,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);

--- a/packages/php-wasm/web-builds/8-3/asyncify/php_8_3.js
+++ b/packages/php-wasm/web-builds/8-3/asyncify/php_8_3.js
@@ -5281,40 +5281,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);

--- a/packages/php-wasm/web-builds/8-3/asyncify/php_8_3.js
+++ b/packages/php-wasm/web-builds/8-3/asyncify/php_8_3.js
@@ -4796,6 +4796,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -5159,6 +5160,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](command, args, {
@@ -5187,6 +5211,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
 			if (!peer) {
@@ -5256,7 +5281,7 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
 				if (!resolved) {
@@ -7664,20 +7689,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/web-builds/8-3/jspi/php_8_3.js
+++ b/packages/php-wasm/web-builds/8-3/jspi/php_8_3.js
@@ -4673,6 +4673,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -5036,6 +5037,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](command, args, {
@@ -5064,6 +5088,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
 			if (!peer) {
@@ -5133,7 +5158,7 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
 				if (!resolved) {
@@ -7537,20 +7562,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/web-builds/8-3/jspi/php_8_3.js
+++ b/packages/php-wasm/web-builds/8-3/jspi/php_8_3.js
@@ -5158,40 +5158,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);

--- a/packages/php-wasm/web-builds/8-4/asyncify/php_8_4.js
+++ b/packages/php-wasm/web-builds/8-4/asyncify/php_8_4.js
@@ -5281,40 +5281,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);

--- a/packages/php-wasm/web-builds/8-4/asyncify/php_8_4.js
+++ b/packages/php-wasm/web-builds/8-4/asyncify/php_8_4.js
@@ -4796,6 +4796,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -5159,6 +5160,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](command, args, {
@@ -5187,6 +5211,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
 			if (!peer) {
@@ -5256,7 +5281,7 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
 				if (!resolved) {
@@ -7664,20 +7689,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/web-builds/8-4/jspi/php_8_4.js
+++ b/packages/php-wasm/web-builds/8-4/jspi/php_8_4.js
@@ -4673,6 +4673,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -5036,6 +5037,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](command, args, {
@@ -5064,6 +5088,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
 			if (!peer) {
@@ -5133,7 +5158,7 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
 				if (!resolved) {
@@ -7537,20 +7562,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/web-builds/8-4/jspi/php_8_4.js
+++ b/packages/php-wasm/web-builds/8-4/jspi/php_8_4.js
@@ -5158,40 +5158,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);

--- a/packages/php-wasm/web-builds/8-5/asyncify/php_8_5.js
+++ b/packages/php-wasm/web-builds/8-5/asyncify/php_8_5.js
@@ -5281,40 +5281,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);

--- a/packages/php-wasm/web-builds/8-5/asyncify/php_8_5.js
+++ b/packages/php-wasm/web-builds/8-5/asyncify/php_8_5.js
@@ -4796,6 +4796,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -5159,6 +5160,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](command, args, {
@@ -5187,6 +5211,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
 			if (!peer) {
@@ -5256,7 +5281,7 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
 				if (!resolved) {
@@ -7664,20 +7689,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/web-builds/8-5/jspi/php_8_5.js
+++ b/packages/php-wasm/web-builds/8-5/jspi/php_8_5.js
@@ -4673,6 +4673,7 @@ export function init(RuntimeName, PHPLoader) {
 		O_NONBLOCK: 2048,
 		POLLHUP: 16,
 		SETFL_MASK: 3072,
+		socketTimeouts: new Map,
 		init: function () {
 			if (PHPLoader.bindUserSpace) {
 				addOnInit(() => {
@@ -5036,6 +5037,29 @@ export function init(RuntimeName, PHPLoader) {
 			return [promise, cancel];
 		},
 		noop: function () {},
+		parseSocketTimeout: function (optionValuePtr, optionLen) {
+			if (!optionValuePtr || optionLen < 8) {
+				return null;
+			}
+			let seconds;
+			let microseconds;
+			if (optionLen >= 16) {
+				seconds = Number(HEAP64[optionValuePtr >> 3]);
+				microseconds = Number(HEAP64[(optionValuePtr + 8) >> 3]);
+			} else {
+				seconds = HEAP32[optionValuePtr >> 2];
+				microseconds = HEAP32[(optionValuePtr + 4) >> 2];
+			}
+			if (
+				!Number.isFinite(seconds) ||
+				!Number.isFinite(microseconds) ||
+				seconds < 0 ||
+				microseconds < 0
+			) {
+				return null;
+			}
+			return seconds * 1e3 + Math.ceil(microseconds / 1e3);
+		},
 		spawnProcess: function (command, args, options) {
 			if (Module['spawnProcess']) {
 				const spawned = Module['spawnProcess'](command, args, {
@@ -5064,6 +5088,7 @@ export function init(RuntimeName, PHPLoader) {
 			throw e;
 		},
 		shutdownSocket: function (socketd, how) {
+			PHPWASM.socketTimeouts.delete(socketd);
 			const sock = getSocketFromFD(socketd);
 			const peer = Object.values(sock.peers)[0];
 			if (!peer) {
@@ -5133,7 +5158,7 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = 3e4;
+			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
 			let resolved = false;
 			const timeoutId = setTimeout(() => {
 				if (!resolved) {
@@ -7537,20 +7562,34 @@ export function init(RuntimeName, PHPLoader) {
 		const SO_SNDTIMEO = 67;
 		const IPPROTO_TCP = 6;
 		const TCP_NODELAY = 1;
+		if (
+			level === SOL_SOCKET &&
+			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO)
+		) {
+			const timeoutMs = PHPWASM.parseSocketTimeout(
+				optionValuePtr,
+				optionLen
+			);
+			if (timeoutMs === null) {
+				return -1;
+			}
+			const timeouts = PHPWASM.socketTimeouts.get(socketd) || {};
+			if (optionName === SO_RCVTIMEO) {
+				timeouts.receive = timeoutMs;
+			} else {
+				timeouts.send = timeoutMs;
+			}
+			PHPWASM.socketTimeouts.set(socketd, timeouts);
+			return 0;
+		}
 		const isForwardable =
 			(level === SOL_SOCKET && optionName === SO_KEEPALIVE) ||
 			(level === IPPROTO_TCP && optionName === TCP_NODELAY);
-		const isIgnorable =
-			level === SOL_SOCKET &&
-			(optionName === SO_RCVTIMEO || optionName === SO_SNDTIMEO);
-		if (!isForwardable && !isIgnorable) {
+		if (!isForwardable) {
 			console.warn(
 				`Unsupported socket option: ${level}, ${optionName}, ${optionValue}`
 			);
 			return -1;
-		}
-		if (isIgnorable) {
-			return 0;
 		}
 		const ws = PHPWASM.getAllWebSockets(socketd)[0];
 		if (!ws) {

--- a/packages/php-wasm/web-builds/8-5/jspi/php_8_5.js
+++ b/packages/php-wasm/web-builds/8-5/jspi/php_8_5.js
@@ -5158,40 +5158,73 @@ export function init(RuntimeName, PHPLoader) {
 				wakeUp(-ERRNO_CODES.ECONNREFUSED);
 				return;
 			}
-			const timeout = PHPWASM.socketTimeouts.get(sockfd)?.send || 3e4;
+			// Wait for the connection to be established. A zero timeval
+			// disables the timeout, matching SO_SNDTIMEO semantics.
+			const sendTimeout = PHPWASM.socketTimeouts.get(sockfd)?.send;
+			const timeout = sendTimeout ?? 3e4;
 			let resolved = false;
-			const timeoutId = setTimeout(() => {
-				if (!resolved) {
-					resolved = true;
-					wakeUp(-ERRNO_CODES.ETIMEDOUT);
-				}
-			}, timeout);
-			const handleOpen = () => {
-				if (!resolved) {
-					resolved = true;
+			let timeoutId;
+			let handleOpen;
+			let handleError;
+			let handleClose;
+			const peer = PHPWASM.getAllPeers(sock).find(
+				(candidate) => candidate.socket === ws
+			);
+
+			const cleanupConnectListeners = () => {
+				if (typeof timeoutId !== 'undefined') {
 					clearTimeout(timeoutId);
-					ws.removeEventListener('error', handleError);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(0);
+				}
+				ws.removeEventListener('open', handleOpen);
+				ws.removeEventListener('error', handleError);
+				ws.removeEventListener('close', handleClose);
+			};
+
+			const cleanupFailedConnect = (errno) => {
+				try {
+					if (
+						ws.readyState !== ws.CLOSING &&
+						ws.readyState !== ws.CLOSED
+					) {
+						ws.close();
+					}
+				} catch (e) {
+					// Ignore close errors on an already-failed connect.
+				}
+				if (peer) {
+					SOCKFS.websocket_sock_ops.removePeer(sock, peer);
+				}
+				sock.connecting = false;
+				sock.error = errno;
+			};
+
+			const finishConnect = (result) => {
+				if (!resolved) {
+					resolved = true;
+					cleanupConnectListeners();
+					if (result < 0) {
+						cleanupFailedConnect(-result);
+					}
+					wakeUp(result);
 				}
 			};
-			const handleError = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('close', handleClose);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			if (timeout > 0) {
+				timeoutId = setTimeout(() => {
+					finishConnect(-ERRNO_CODES.ETIMEDOUT);
+				}, timeout);
+			}
+
+			handleOpen = () => {
+				finishConnect(0);
 			};
-			const handleClose = () => {
-				if (!resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					ws.removeEventListener('open', handleOpen);
-					ws.removeEventListener('error', handleError);
-					wakeUp(-ERRNO_CODES.ECONNREFUSED);
-				}
+
+			handleError = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
+			};
+
+			handleClose = () => {
+				finishConnect(-ERRNO_CODES.ECONNREFUSED);
 			};
 			ws.addEventListener('open', handleOpen);
 			ws.addEventListener('error', handleError);


### PR DESCRIPTION
Tracks #38 and revives upstream WordPress/wordpress-playground#3156 against current fork trunk.

## Summary
- Store `SO_RCVTIMEO` and `SO_SNDTIMEO` values from `wasm_setsockopt()` instead of acknowledging them as ignored.
- Enforce `SO_RCVTIMEO` in `wasm_recv()` by returning `EAGAIN` once the configured receive timeout elapses.
- Apply `SO_SNDTIMEO` to JSPI `wasm_connect()` connection establishment, preserving explicit zero timeouts and only using the 30s fallback when no send timeout is configured.
- Clean up failed connection attempts by removing listeners, closing/removing the pending WebSocket peer, resetting `sock.connecting`, and setting `sock.error`.
- Refresh checked-in node/web PHP loader builds, including missing `parseSocketTimeout()` definitions in generated Node loaders, and run the structural regression test in both asyncify and JSPI targets.

## Validation
- `git diff --check`
- `npx prettier --check packages/php-wasm/node/src/test/php-socket-timeouts.spec.ts packages/php-wasm/node/project.json`
- `node --check` on all checked-in `packages/php-wasm/**/php_*.js` loaders
- `npx nx run php-wasm-node:test-group-2-asyncify --skip-nx-cache --testFiles=php-socket-timeouts.spec.ts`
- `npx nx run php-wasm-node:test-group-2-jspi --skip-nx-cache --testFiles=php-socket-timeouts.spec.ts`
- `npx nx run php-wasm-node:lint --skip-nx-cache`
- `npx nx run php-wasm-node:typecheck --skip-nx-cache`
- `npx nx run php-wasm-node:build:bundle --skip-nx-cache`
- `npx nx run php-wasm-web:build:bundle --skip-nx-cache`
- `PHP=8.5 npx nx run php-wasm-node:test-group-4-asyncify --skip-nx-cache --testFiles=php-networking.spec.ts --testNamePattern="should be able to make a request to a server"`

## Notes
- Local JSPI runtime integration coverage is still limited by this Node runtime: `WebAssembly.Suspending` is unavailable in Node v22.20.0, even with experimental JSPI/stack-switching flags. The PR now includes JSPI structural coverage and CI should cover runtime JSPI jobs.
- Current head: `b56bfdd7b3caa41a6a11aadf0830a377e470d948`.