### PR TITLE
Stabilize shared CI browser smokes

### DIFF
--- a/.github/actions/prepare-playground/action.yml
+++ b/.github/actions/prepare-playground/action.yml
@@ -42,3 +42,6 @@ runs:
         - name: Reset NX cache
           shell: bash
           run: npx nx reset
+        - name: Reset Vite cache
+          shell: bash
+          run: rm -rf node_modules/.vite

--- a/packages/playground/personal-wp/playwright/e2e/ui.spec.ts
+++ b/packages/playground/personal-wp/playwright/e2e/ui.spec.ts
@@ -90,6 +90,6 @@ test('should navigate within WordPress from Site Tools shortcuts', async ({
 	).toBeVisible();
 
 	await website.page.getByRole('button', { name: 'Homepage' }).click();
-	await expect(website.page).toHaveURL(/\/$/);
-	await expect(wordpress.locator('p.wp-block-site-title')).toBeVisible();
+	await expect(website.page).toHaveURL(/\/my-apps\/$/);
+	await expect(wordpress.locator('body')).toContainText('My Apps');
 });

--- a/packages/playground/personal-wp/playwright/playwright.config.ts
+++ b/packages/playground/personal-wp/playwright/playwright.config.ts
@@ -7,10 +7,10 @@ const baseURL =
 
 export const playwrightConfig: PlaywrightTestConfig = {
 	testDir: './e2e',
-	fullyParallel: true,
+	fullyParallel: !process.env.CI,
 	forbidOnly: !!process.env.CI,
 	retries: 3,
-	workers: 3,
+	workers: process.env.CI ? 1 : 3,
 	reporter: [['html'], ['list', { printSteps: true }]],
 	use: {
 		baseURL,

--- a/packages/playground/remote/vite.config.ts
+++ b/packages/playground/remote/vite.config.ts
@@ -70,6 +70,25 @@ export default defineConfig(({ mode }) => {
 			'*.zip',
 		],
 		cacheDir: '../../../node_modules/.vite/playground',
+		// Personal WP serves this app through another Vite dev server. Pre-bundle
+		// the runtime deps before the first browser request to avoid optimizer
+		// reloads while WordPress is booting in the iframe.
+		optimizeDeps: {
+			include: [
+				'@zip.js/zip.js',
+				'async-lock',
+				'buffer',
+				'crc-32',
+				'diff3',
+				'ignore',
+				'ini',
+				'octokit',
+				'pako',
+				'pify',
+				'sha.js/sha1.js',
+				'wasm-feature-detect',
+			],
+		},
 		// Bundled WordPress files live in a separate dependency-free `wordpress`
 		// package so that every package may use them without causing circular
 		// dependencies.

--- a/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+++ b/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
@@ -84,6 +84,7 @@ const WP_VERSIONS = [
 
 const PORT = 5400;
 const TIMEOUT_S = 120;
+const PLUGIN_ACTIVATION_TIMEOUT_S = 90;
 const results = [];
 
 /**
@@ -262,6 +263,7 @@ async function waitForPluginActivation(
 	timeoutSeconds = 60
 ) {
 	const deadline = Date.now() + timeoutSeconds * 1000;
+	let lastChanged = null;
 	while (Date.now() < deadline) {
 		await page.waitForTimeout(500);
 		for (const frame of page.frames()) {
@@ -273,18 +275,99 @@ async function waitForPluginActivation(
 				const changed =
 					frame.url() !== previousFrameUrl || body !== previousBody;
 				if (!changed) continue;
-				if (
-					body.includes('Plugin activated') ||
-					body.includes('Deactivate') ||
-					body.includes('Are you sure') ||
-					findPHPError(body)
-				) {
-					return { body, frame };
+				lastChanged = { body, frame };
+				if (await hasPluginActivationResult(body, frame)) {
+					return lastChanged;
 				}
 			} catch {}
 		}
 	}
+	return lastChanged;
+}
+
+async function hasPluginDeactivateLink(frame) {
+	try {
+		const helloDeactivate = frame
+			.locator('a[href*="hello.php"]')
+			.filter({ hasText: /^Deactivate$/ })
+			.first();
+		if ((await helloDeactivate.count()) > 0) {
+			return true;
+		}
+		return (
+			(await frame
+				.locator('a')
+				.filter({ hasText: /^Deactivate$/ })
+				.count()) > 0
+		);
+	} catch {
+		return false;
+	}
+}
+
+async function hasPluginActivated(wpPage) {
+	return (
+		wpPage.body.includes('Plugin activated') ||
+		(await hasPluginDeactivateLink(wpPage.frame))
+	);
+}
+
+async function hasPluginActivationResult(body, frame) {
+	return (
+		body.includes('Plugin activated') ||
+		(await hasPluginDeactivateLink(frame)) ||
+		body.includes('Are you sure') ||
+		findPHPError(body)
+	);
+}
+
+async function findPluginActivateLink(frame) {
+	// Wait for any Activate link to render — navigateViaUrlBar returns as soon
+	// as plugins.php has *any* body text, which on slow CI boots can be just
+	// the admin shell before the plugin list renders.
+	const anyActivate = frame
+		.locator('a')
+		.filter({ hasText: 'Activate' })
+		.first();
+	try {
+		await anyActivate.waitFor({
+			state: 'visible',
+			timeout: 15000,
+		});
+	} catch {}
+
+	const helloActivate = frame
+		.locator('a[href*="hello.php"]')
+		.filter({ hasText: 'Activate' })
+		.first();
+	if ((await helloActivate.count()) > 0) {
+		return helloActivate;
+	}
+	if ((await anyActivate.count()) > 0) {
+		return anyActivate;
+	}
 	return null;
+}
+
+async function clickPluginActivateLink(page, wpPage) {
+	const activateLink = await findPluginActivateLink(wpPage.frame);
+	if (!activateLink) {
+		return { found: false, page: null };
+	}
+
+	const bodyBeforeActivation = await wpPage.frame
+		.locator('body')
+		.innerText({ timeout: 2000 })
+		.catch(() => wpPage.body);
+	const prevFrameUrl = wpPage.frame.url();
+	await activateLink.click({ timeout: 5000 });
+	const activatedPage = await waitForPluginActivation(
+		page,
+		prevFrameUrl,
+		bodyBeforeActivation,
+		PLUGIN_ACTIVATION_TIMEOUT_S
+	);
+	return { found: true, page: activatedPage };
 }
 
 /**
@@ -693,47 +776,55 @@ for (const { wp, php } of MATRIX) {
 					// Fall back to the first Activate link for very old WP
 					// where Hello Dolly may not be present or the href
 					// format differs.
-					// Wait for any Activate link to render — navigateViaUrlBar
-					// returns as soon as plugins.php has *any* body text, which
-					// on slow CI boots can be just the admin shell before the
-					// plugin list renders.
-					const anyActivate = wp4.frame
-						.locator('a')
-						.filter({ hasText: 'Activate' })
-						.first();
-					try {
-						await anyActivate.waitFor({
-							state: 'visible',
-							timeout: 15000,
-						});
-					} catch {}
-					const helloActivate = wp4.frame
-						.locator('a[href*="hello.php"]')
-						.filter({ hasText: 'Activate' })
-						.first();
-					const activateLink =
-						(await helloActivate.count()) > 0
-							? helloActivate
-							: anyActivate;
-					if ((await activateLink.count()) > 0) {
-						const bodyBeforeActivation = await wp4.frame
-							.locator('body')
-							.innerText({ timeout: 2000 })
-							.catch(() => wp4.body);
-						const prevFrameUrl = wp4.frame.url();
-						await activateLink.click({ timeout: 5000 });
-						const wp4b = await waitForPluginActivation(
+					let pluginsPage = wp4;
+					let wp4b = null;
+					let foundActivateLink = false;
+					for (let attempt = 0; attempt < 2; attempt++) {
+						const activation = await clickPluginActivateLink(
 							page,
-							prevFrameUrl,
-							bodyBeforeActivation
+							pluginsPage
 						);
+						foundActivateLink ||= activation.found;
+						wp4b = activation.page || wp4b;
+
+						if (
+							activation.page &&
+							(await hasPluginActivationResult(
+								activation.page.body,
+								activation.page.frame
+							))
+						) {
+							break;
+						}
+
+						const refreshedPluginsPage = await navigateViaUrlBar(
+							page,
+							'/wp-admin/plugins.php',
+							30
+						);
+						if (
+							refreshedPluginsPage &&
+							(await hasPluginActivated(refreshedPluginsPage))
+						) {
+							wp4b = refreshedPluginsPage;
+							break;
+						}
+
+						if (attempt === 0 && refreshedPluginsPage) {
+							pluginsPage = refreshedPluginsPage;
+							wp4b = refreshedPluginsPage;
+							continue;
+						}
+
+						wp4b = refreshedPluginsPage || wp4b;
+						break;
+					}
+					if (foundActivateLink) {
 						if (!wp4b) {
 							pluginStatus = { status: 'TIMEOUT' };
 						} else {
 							const error = findPHPError(wp4b.body);
-							const ok =
-								wp4b.body.includes('Plugin activated') ||
-								wp4b.body.includes('Deactivate');
+							const ok = await hasPluginActivated(wp4b);
 							const bad = wp4b.body.includes('Are you sure');
 							if (error) {
 								pluginStatus = {


### PR DESCRIPTION
## Summary
- pre-bundle the remote Vite runtime dependencies before Personal WP e2e starts loading nested WordPress iframes
- clear Vite's optimizer cache after restoring cached `node_modules` in the shared CI prepare action
- keep Personal WP e2e serial in CI while preserving local parallelism
- align the Site Tools Homepage assertion with the current `/my-apps/` landing page
- include the legacy WordPress plugin activation smoke retry/readback fix from #66

## Why
Two shared CI failures were masking unrelated fork PRs:

- `test-e2e-personal-wp` hit Vite optimized-dependency reloads while WordPress was booting, producing missing chunk diagnostics and empty nested iframe bodies. A local clean-cache run reproduced the missing-chunk warning before this fix; the patched dev-server smoke passed without those diagnostics.
- `test-legacy-wp-version-boot` could lose or misread plugin activation on older WordPress versions. The legacy smoke now verifies the actual `Deactivate` action after activation and retries once when the activation page does not reflect the expected state.

Tracks #63 and #65.

## Validation
- `git diff --check`
- `node --check packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs`
- `npx prettier --check .github/actions/prepare-playground/action.yml packages/playground/remote/vite.config.ts packages/playground/personal-wp/playwright/playwright.config.ts packages/playground/personal-wp/playwright/e2e/ui.spec.ts packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs`
- `NX_DAEMON=false npx nx run playground-personal-wp:lint --skip-nx-cache`
- `NX_DAEMON=false npx nx run playground-personal-wp:typecheck --skip-nx-cache`
- `NX_DAEMON=false npx nx run playground-remote:lint --skip-nx-cache`
- `NX_DAEMON=false npx nx run playground-remote:typecheck --skip-nx-cache`
- `NX_DAEMON=false npx nx run playground-wordpress:lint --skip-nx-cache`
- `NX_DAEMON=false npx nx run playground-wordpress:test:vite --skip-nx-cache`
- Clean-cache local dev-server smoke with system Chromium for the failing Personal WP Site Tools navigation path; passed without Vite missing-chunk diagnostics.
- Earlier #66 branch validation: `WP_ONLY=5.8,5.3,3.2 node packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs` against the local dev server with system Chromium passed.

## CI Notes
The refreshed #64 run at `4be63112` passed `test-e2e-personal-wp`. The branch now includes the legacy smoke fix too, so CI is re-running at `41bf8efc`.