### PR TITLE
Add native view transition fallback for Playground pages

### DIFF
--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -45,6 +45,76 @@ add_action('admin_head', function () {
 		</style>';
 });
 
+/**
+ * Opt Playground pages into browser-native cross-document View Transitions.
+ *
+ * This lets the browser keep the outgoing page visible until the incoming page
+ * is ready, without intercepting clicks or emulating navigation.
+ * The rules are intentionally low-specificity and printed early, so themes,
+ * plugins, and user code can override them with ordinary CSS.
+ */
+function playground_enable_view_transitions() {
+	if (playground_has_wordpress_view_transitions()) {
+		return;
+	}
+
+	?>
+	<style>
+		@media (prefers-reduced-motion: no-preference) {
+			@view-transition {
+				navigation: auto;
+			}
+
+			::view-transition-group(root),
+			::view-transition-old(root),
+			::view-transition-new(root) {
+				animation-delay: 0s;
+				animation-duration: 0s;
+			}
+
+			::view-transition-old(root),
+			::view-transition-new(root) {
+				mix-blend-mode: normal;
+			}
+		}
+	</style>
+	<?php
+}
+
+/**
+ * Checks whether WordPress already owns View Transitions for this request.
+ *
+ * The Playground fallback avoids named transitions, but it should still step
+ * aside when Core or the feature plugin can define its own root transition.
+ */
+function playground_has_wordpress_view_transitions() {
+	// The standalone View Transitions feature plugin defines these globally.
+	if (defined('VIEW_TRANSITIONS_VERSION')
+		|| function_exists('plvt_load_view_transitions')) {
+		return true;
+	}
+
+	if (!function_exists('is_admin') || !is_admin()) {
+		return false;
+	}
+
+	// Core exposes these helpers while its admin View Transitions are available.
+	if (function_exists('wp_get_view_transitions_admin_css')
+		|| function_exists('wp_enqueue_view_transitions_admin_css')) {
+		return true;
+	}
+
+	return function_exists('wp_style_is')
+		&& (
+			wp_style_is('wp-view-transitions-admin', 'registered')
+			|| wp_style_is('wp-view-transitions-admin', 'enqueued')
+			|| wp_style_is('wp-view-transitions-admin', 'done')
+		);
+}
+add_action('wp_head', 'playground_enable_view_transitions', 0);
+add_action('admin_print_styles', 'playground_enable_view_transitions', 0);
+add_action('login_head', 'playground_enable_view_transitions', 0);
+
 add_action('init', 'networking_disabled');
 function networking_disabled() {
 	$networking_err_msg = '<div class="networking_err_msg">Network access is an <a href="https://github.com/WordPress/wordpress-playground/issues/85" target="_blank">experimental, opt-in feature</a>, which means you need to enable it to allow Playground to access the Plugins/Themes directories.


### PR DESCRIPTION
## What it does

Adds a small View Transitions fallback to the Playground mu-plugin so WordPress documents opt into browser-native cross-document navigation handoffs.

The fallback applies to frontend, wp-admin, and login pages. It makes the root page snapshot swap sharply (`0s`) so iframe navigations do not flash blank content between documents.

## Rationale

Iframe navigations can clear the frame between the outgoing and incoming document. Cross-document View Transitions let the browser keep the outgoing page snapshot visible until the incoming page is ready, without intercepting clicks or reimplementing navigation semantics.

Related: [WordPress Core Trac #64470](https://core.trac.wordpress.org/ticket/64470). That ticket adds Core-owned WP Admin View Transitions via the `wp-view-transitions-admin` style and `wp_enqueue_view_transitions_admin_css()`. This PR covers the gap for Playground pages that do not yet have a WordPress-owned transition, and it backs off when those Core/plugin signals are present so WordPress can define its own transitions.

Related Playground issue: [WordPress/wordpress-playground#3436](https://github.com/WordPress/wordpress-playground/issues/3436). That issue reports wp-admin screens going blank after clicking around in Playground with WordPress 7.0 RC1. This PR addresses the same browser-navigation class of problem for pages where WordPress has not already opted into View Transitions, while deliberately backing off for Core-owned WordPress 7.0 admin transitions so it does not mask or conflict with that investigation.

## Implementation

The CSS is printed early and without `!important`:

- `@view-transition { navigation: auto; }` opts eligible documents into native cross-document transitions.
- Root-only `::view-transition-*` rules set `animation-duration: 0s` for a sharp swap.
- Named View Transitions from Core, Gutenberg, themes, or plugins are left alone.

Playground backs off when WordPress already owns View Transitions:

- the View Transitions feature plugin is active (`VIEW_TRANSITIONS_VERSION` / `plvt_load_view_transitions`)
- Core admin View Transitions are available (`wp_get_view_transitions_admin_css`, `wp_enqueue_view_transitions_admin_css`, or `wp-view-transitions-admin`)

## Testing instructions

```bash
php -l packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
git diff --check HEAD^..HEAD
```

Manual Chrome MCP checks with `npm run dev` at `http://127.0.0.1:5400/website-server/`:

- WordPress 6.9 frontend/wp-admin/login pages include the fallback CSS.
- Dashboard -> Posts emits native `pageswap` with `viewTransition: true`.
- The fallback uses root-only selectors and no `!important`.
- WordPress beta wp-admin does not include the Playground fallback when Core emits `wp-view-transitions-admin-inline-css`.
